### PR TITLE
KIWI-1322: Github migration - Post clean up for IPVReturn API

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # This is the CODEOWNERS file. These owners will be the default owners for everything in the di-ipvreturn-api repository
 # The following below will be requested for review when someone opens a pull request.
 
-* @alphagov/di-ipv-kiwi-api-codeowners
+* @govuk-one-login/kiwi-api-codeowners
 
 # The following allows QA to review changes to /tests directory
 
-tests/ @alphagov/di-ipv-kiwi-qa-codeowners @alphagov/di-ipv-kiwi-api-codeowners
+tests/ @govuk-one-login/kiwi-qa-codeowners @govuk-one-login/kiwi-api-codeowners

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!-- Provide a general summary of your changes in the Title above -->
-<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXX] PR Title` -->
+<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->
 
 ## Proposed changes
 
@@ -16,7 +16,7 @@
 <!-- List any related ADRs or RFCs -->
 <!-- Delete/copy as appropriate -->
 
-- [KIWI-XXX](https://govukverify.atlassian.net/browse/KIWI-XXX)
+- [KIWI-XXXX](https://govukverify.atlassian.net/browse/KIWI-XXXX)
 
 ## Checklists
 


### PR DESCRIPTION
- Add the CODEOWNERS for new govuk-one-login github IPR API
- Modified the urls pointing to alphagov github repository

- [KIWI-1322](https://govukverify.atlassian.net/browse/KIWI-1322)

[KIWI-1322]: https://govukverify.atlassian.net/browse/KIWI-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ