### PR TITLE
Capture expired IPR Sessions

### DIFF
--- a/src/services/IPRService.ts
+++ b/src/services/IPRService.ts
@@ -62,10 +62,10 @@ export class IPRService {
 		}
 
 		if (session.Item) {
-			if (session.Item.expiresOn < absoluteTimeNow()) {
-				this.logger.error({ message: "Session has expired", messageCode: MessageCodes.SESSION_EXPIRED });
-				throw new AppError( HttpCodesEnum.UNAUTHORIZED, "Session has expired");
-			}
+			// if (session.Item.expiresOn < absoluteTimeNow()) {
+			// 	this.logger.error({ message: "Session has expired", messageCode: MessageCodes.SESSION_EXPIRED });
+			// 	throw new AppError( HttpCodesEnum.UNAUTHORIZED, "Session has expired");
+			// }
 			return session.Item as ExtSessionEvent;
 		}
 	}

--- a/src/tests/unit/services/IPRService.test.ts
+++ b/src/tests/unit/services/IPRService.test.ts
@@ -204,7 +204,7 @@ describe("IPR Service", () => {
 	});
 
 	describe("getSessionBySub", () => {
-		it("Should throw error if session has expired", async () => {
+		it.skip("Should throw error if session has expired", async () => {
 			mockDynamoDbClient.send = jest.fn().mockResolvedValue({
 				Item: {
 					expiresOn: absoluteTimeNow() - 1000,


### PR DESCRIPTION
### What changed
Removes logic to capture IPR Sessions that have expired