### PR TITLE
[KIWI-1362] - Remove DynamoDB TimeToLiveSpecification

### DIFF
--- a/infra-l2-dynamo/template.yaml
+++ b/infra-l2-dynamo/template.yaml
@@ -71,9 +71,9 @@ Resources:
       KeySchema:
         - AttributeName: "userId"
           KeyType: "HASH"
-      TimeToLiveSpecification:
-        AttributeName: expiryDate
-        Enabled: true
+      # TimeToLiveSpecification:
+      #   AttributeName: expiresOn
+      #   Enabled: true
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
       SSESpecification:


### PR DESCRIPTION
### What changed

Remove DynamoDB TimeToLiveSpecification to allow for attribute name to be change in future PR: https://github.com/govuk-one-login/ipvreturn-api/pull/100

**Before**
<img width="1526" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/8135c9ec-671d-4bd3-880e-67e048414521">


**After**
<img width="1030" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/7ef8fe9e-63db-4d79-b882-6ddbceba8298">


