### PR TITLE
[KIWI-1362] Enable TTL and set Attribute name to expiresOn

### DIFF
--- a/infra-l2-dynamo/template.yaml
+++ b/infra-l2-dynamo/template.yaml
@@ -71,9 +71,9 @@ Resources:
       KeySchema:
         - AttributeName: "userId"
           KeyType: "HASH"
-      TimeToLiveSpecification:
-        AttributeName: expiryDate
-        Enabled: true
+      # TimeToLiveSpecification:
+      #   AttributeName: expiresOn
+      #   Enabled: true
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
       SSESpecification:

--- a/infra-l2-dynamo/template.yaml
+++ b/infra-l2-dynamo/template.yaml
@@ -71,9 +71,9 @@ Resources:
       KeySchema:
         - AttributeName: "userId"
           KeyType: "HASH"
-      # TimeToLiveSpecification:
-      #   AttributeName: expiresOn
-      #   Enabled: true
+      TimeToLiveSpecification:
+        AttributeName: expiresOn
+        Enabled: true
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
       SSESpecification:


### PR DESCRIPTION
### What changed

Update DynamoDB TimeToLiveSpecification AttributeName to match the record after having deleted it in PR: https://github.com/govuk-one-login/ipvreturn-api/pull/98

**Before**
<img width="1030" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/7ef8fe9e-63db-4d79-b882-6ddbceba8298">

**Run Preview**
<img width="838" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/9d295233-35d0-4a9f-b412-34e9d9cb57ab">


**After**
<img width="1037" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/48d2d32f-468d-4653-a126-dc47e0aeb59d">


