### PR TITLE
[KIWI-1203] - Create new NotLocalTestStack condition to allow multiple deployments of IPR BE Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ The gov-notify-templates directory contains the templates required for sending e
 
 If you need the reserved concurrencies set in DEV then add `ApplyReservedConcurrencyInDev=\"true\"` in to the `--parameter-overrides`.
 Please only do this whilst you need them, if lots of stacks are deployed with these in DEV then deployments will start failing.
+
+## Local development
+
+For local development deploy a custom stack:
+1. `cd /deploy`
+2. In samconfig.toml change `stack_name` to a custom stack name of your choice
+3. Log in using AWS SSO
+4. Deploy by running `sam build && sam deploy --config-env dev --resolve-s3`
+
+Note: When deploying custom stacks in dev NotLocalTestStack will prevent the deploy of Custom Domains and OIDCProvider unless the stackname is ipvreturn-api
+If you require a BE stack with those capabilities please use the "Deploy Main to Dev Env" Github Workflow with your branch to deploy your changes to the main Dev Stack
+

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -228,6 +228,16 @@ Conditions:
     - Condition: DeployAlarms
     - Condition: ApplyReservedConcurrency
   PerformanceTestEnv: !Equals [ !Ref Environment, build]
+  NotLocalTestStack:
+    Fn::Not:
+      - Fn::And:
+          - Fn::Equals:
+              - !Ref Environment
+              - dev
+          - Fn::Not:
+              - Fn::Equals:
+                  - !Sub "${AWS::StackName}"
+                  - "ipvreturn-api"
 
 Globals:
   Function:
@@ -279,6 +289,7 @@ Resources:
   ### OIDC Provider as IAM entity
   OIDCProvider:
     Type: AWS::IAM::OIDCProvider
+    Condition: NotLocalTestStack
     Properties:
       ClientIdList:
         - !Sub "{{resolve:ssm:/${Environment}/ipvreturn/CLIENT_ID}}"
@@ -289,6 +300,7 @@ Resources:
   ### AssumeRoleWithWebIdentityRole
   AssumeRoleWithWebIdentityRole:
     Type: "AWS::IAM::Role"
+    Condition: NotLocalTestStack
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -424,6 +436,7 @@ Resources:
 
   IPVRApiCustomDomain:
     Type: AWS::ApiGateway::DomainName
+    Condition: NotLocalTestStack
     Properties:
       DomainName: !Sub
         - "api.${DNSSUFFIX}"
@@ -437,6 +450,7 @@ Resources:
 
   IPVRApiCertificateRecord:
     Type: AWS::Route53::RecordSet
+    Condition: NotLocalTestStack
     Properties:
       Name: !Sub
         - "api.${DNSSUFFIX}"
@@ -450,6 +464,7 @@ Resources:
 
   IPVRApiMapping:
     Type: AWS::ApiGateway::BasePathMapping
+    Condition: NotLocalTestStack
     DependsOn: IPVRApiCustomDomain
     Properties:
       DomainName: !Sub
@@ -1040,7 +1055,11 @@ Resources:
           CLIENT_ID_SSM_PATH: !Sub "/${Environment}/ipvreturn/CLIENT_ID"
           OIDC_URL: !FindInMap [ EnvironmentVariables, !Ref Environment, OIDCURL ]
           RETURN_REDIRECT_URL: !FindInMap [ EnvironmentVariables, !Ref Environment, RETURNREDIRECTURL ]
-          ASSUMEROLE_WITH_WEB_IDENTITY_ARN: !GetAtt AssumeRoleWithWebIdentityRole.Arn
+          ASSUMEROLE_WITH_WEB_IDENTITY_ARN:
+            Fn::If:
+              - NotLocalTestStack
+              - !GetAtt AssumeRoleWithWebIdentityRole.Arn
+              - !Ref AWS::NoValue
           TXMA_QUEUE_URL: !Ref TxMASQSQueue
       Policies:
         - AWSLambdaBasicExecutionRole


### PR DESCRIPTION
### What changed

"Introduced CloudFormation condition **NotLocalTestStack** to enable or disable the deployment of resources based on the environment not being 'dev' and the AWS CloudFormation stack name not being 'ipvreturn-api'."


**Local Deploy**
<img width="802" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/15a25b34-68b8-42f9-befd-e6cd79fcaed6">

<img width="1336" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/e8d9b0b2-2ae9-4c35-8dd1-c4b84942f33c">
<img width="1059" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/b1e94851-9c6c-4ad7-8505-d8849d8f87dd">
<img width="1077" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/0449f101-ab23-4a25-bb8f-2b1bdf3e854f">


**CodePipeline Deploy**
<img width="436" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/b3f89373-6f49-455d-9e2c-4e32fae8b0ce">
<img width="1342" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/e559f43f-4c03-4ce7-bb07-d47fe227abf8">


<img width="1064" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/a7e09a3f-e4f4-4507-a249-2c0bc5ce574e">

<img width="1078" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/03c63691-d19e-4c1b-8b30-98bd137ae559">

