### PR TITLE
[KIWI-1386] - Remove stacktrace from error log when getSessionBySub

### DIFF
--- a/src/services/IPRService.ts
+++ b/src/services/IPRService.ts
@@ -57,7 +57,7 @@ export class IPRService {
 		try {
 			session = await this.dynamo.send(getSessionCommand);
 		} catch (error: any) {
-			this.logger.error({ message: "getSessionByUserId - failed executing get from dynamodb:", error });
+			this.logger.error({ message: "getSessionByUserId - failed executing get from dynamodb:" });
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error retrieving Session");
 		}
 

--- a/src/services/SendEmailProcessor.ts
+++ b/src/services/SendEmailProcessor.ts
@@ -68,7 +68,7 @@ export class SendEmailProcessor {
 			this.logger.info("Session retrieved from session store");
 
 		} catch (error) {
-			this.logger.error({ message: "getSessionByUserId - failed executing get from dynamodb:", error }, { messageCode: MessageCodes.ERROR_RETRIEVING_SESSION });
+			this.logger.error({ message: "getSessionByUserId - failed executing get from dynamodb:" }, { messageCode: MessageCodes.ERROR_RETRIEVING_SESSION });
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error retrieving Session");
 		}
 

--- a/src/services/SessionProcessor.ts
+++ b/src/services/SessionProcessor.ts
@@ -138,7 +138,7 @@ export class SessionProcessor {
 				this.logger.debug("Session retrieved from session store");
 
 			} catch (error) {
-				this.logger.error({ message: "getSessionByUserId - Error retrieving Session" }, { messageCode: MessageCodes.ERROR_RETRIEVING_SESSION, error });
+				this.logger.error({ message: "getSessionByUserId - Error retrieving Session" }, { messageCode: MessageCodes.ERROR_RETRIEVING_SESSION });
 				throw new AppError(HttpCodesEnum.UNAUTHORIZED, "Error retrieving Session");
 			}
 

--- a/src/tests/unit/services/IPRService.test.ts
+++ b/src/tests/unit/services/IPRService.test.ts
@@ -219,7 +219,7 @@ describe("IPR Service", () => {
 			mockDynamoDbClient.send = jest.fn().mockRejectedValue({});
 
 			await expect(iprService.getSessionBySub(userId)).rejects.toThrow(new AppError(HttpCodesEnum.SERVER_ERROR, "Error retrieving Session"));
-			expect(logger.error).toHaveBeenCalledWith({ message: "getSessionByUserId - failed executing get from dynamodb:", error: {} });
+			expect(logger.error).toHaveBeenCalledWith({ message: "getSessionByUserId - failed executing get from dynamodb:" });
 		});
 
 		it("Should return the valid session fetched from dynamo", async () => {


### PR DESCRIPTION
### What changed

Remove stacktrace from getSessionBySub method call 
Prod incident userIds being leaked into splunk