### PR TITLE
[KIWI-1365] - Add new obfuscateJSONValues method and log out obfuscated TxMA Events

### DIFF
--- a/src/services/IPRService.ts
+++ b/src/services/IPRService.ts
@@ -177,7 +177,7 @@ export class IPRService {
 				return obfuscatedObject;
 			}
 		} else {
-			return input === null || input === undefined ? input : '***';
+			return input === null || input === undefined ? input : "***";
 		}
 	}
 }

--- a/src/services/IPRService.ts
+++ b/src/services/IPRService.ts
@@ -150,9 +150,8 @@ export class IPRService {
 			await sqsClient.send(new SendMessageCommand(params));
 			this.logger.info("Sent message to TxMA");
 
-			this.obfuscateJSONValues(event, Constants.TXMA_FIELDS_TO_SHOW).then((obfuscatedObject) => {
-				this.logger.info({ message: "Obfuscated TxMA Event", txmaEvent: JSON.stringify(obfuscatedObject, null, 2) });
-			});
+			const obfuscatedObject = await this.obfuscateJSONValues(event, Constants.TXMA_FIELDS_TO_SHOW);
+			this.logger.info({ message: "Obfuscated TxMA Event", txmaEvent: JSON.stringify(obfuscatedObject, null, 2) });
 		} catch (error) {
 			this.logger.error({ message: "Error when sending message to TXMA Queue", error });
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, "sending event to txma queue - failed");
@@ -166,7 +165,7 @@ export class IPRService {
 			} else {
 				const obfuscatedObject: any = {};
 				for (const key in input) {
-					if (input.hasOwnProperty(key)) {
+					if (Object.prototype.hasOwnProperty.call(input, key)) {
 						if (txmaFieldsToShow.includes(key)) {
 							obfuscatedObject[key] = input[key];
 						} else {

--- a/src/services/IPRService.ts
+++ b/src/services/IPRService.ts
@@ -149,9 +149,35 @@ export class IPRService {
 			this.logger.info({ message: "Sending message to TxMA", eventName: event.event_name });
 			await sqsClient.send(new SendMessageCommand(params));
 			this.logger.info("Sent message to TxMA");
+
+			this.obfuscateJSONValues(event, Constants.TXMA_FIELDS_TO_SHOW).then((obfuscatedObject) => {
+				this.logger.info({ message: "Obfuscated TxMA Event", txmaEvent: JSON.stringify(obfuscatedObject, null, 2) });
+			});
 		} catch (error) {
 			this.logger.error({ message: "Error when sending message to TXMA Queue", error });
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, "sending event to txma queue - failed");
+		}
+	}
+
+	async obfuscateJSONValues(input: any, txmaFieldsToShow: string[] = []): Promise<any> {
+		if (typeof input === "object" && input !== null) {
+			if (Array.isArray(input)) {
+				return Promise.all(input.map((element) => this.obfuscateJSONValues(element, txmaFieldsToShow)));
+			} else {
+				const obfuscatedObject: any = {};
+				for (const key in input) {
+					if (input.hasOwnProperty(key)) {
+						if (txmaFieldsToShow.includes(key)) {
+							obfuscatedObject[key] = input[key];
+						} else {
+							obfuscatedObject[key] = await this.obfuscateJSONValues(input[key], txmaFieldsToShow);
+						}
+					}
+				}
+				return obfuscatedObject;
+			}
+		} else {
+			return input === null || input === undefined ? input : '***';
 		}
 	}
 }

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -46,9 +46,8 @@ export class PostEventProcessor {
 			const eventDetails: ReturnSQSEvent = JSON.parse(eventBody);
 			const eventName = eventDetails.event_name;
 
-			this.iprService.obfuscateJSONValues(eventDetails, Constants.TXMA_FIELDS_TO_SHOW).then((obfuscatedObject) => {
-				this.logger.info({ message: "Obfuscated TxMA Event", txmaEvent: JSON.stringify(obfuscatedObject, null, 2) });
-			});
+			const obfuscatedObject = await this.iprService.obfuscateJSONValues(event, Constants.TXMA_FIELDS_TO_SHOW);
+			this.logger.info({ message: "Obfuscated TxMA Event", txmaEvent: obfuscatedObject });
 
 			if (!eventDetails.event_id) {
 				this.logger.error({ message: "Missing event_id in the incoming SQS event" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -46,6 +46,10 @@ export class PostEventProcessor {
 			const eventDetails: ReturnSQSEvent = JSON.parse(eventBody);
 			const eventName = eventDetails.event_name;
 
+			this.iprService.obfuscateJSONValues(eventDetails, Constants.TXMA_FIELDS_TO_SHOW).then((obfuscatedObject) => {
+				this.logger.info({ message: "Obfuscated TxMA Event", txmaEvent: JSON.stringify(obfuscatedObject, null, 2) });
+			});
+
 			if (!eventDetails.event_id) {
 				this.logger.error({ message: "Missing event_id in the incoming SQS event" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
 				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Missing info in sqs event");

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -46,7 +46,7 @@ export class PostEventProcessor {
 			const eventDetails: ReturnSQSEvent = JSON.parse(eventBody);
 			const eventName = eventDetails.event_name;
 
-			const obfuscatedObject = await this.iprService.obfuscateJSONValues(event, Constants.TXMA_FIELDS_TO_SHOW);
+			const obfuscatedObject = await this.iprService.obfuscateJSONValues(eventDetails, Constants.TXMA_FIELDS_TO_SHOW);
 			this.logger.info({ message: "Obfuscated TxMA Event", txmaEvent: obfuscatedObject });
 
 			if (!eventDetails.event_id) {

--- a/src/tests/unit/services/IPRService.test.ts
+++ b/src/tests/unit/services/IPRService.test.ts
@@ -233,4 +233,86 @@ describe("IPR Service", () => {
 			expect(result).toEqual(Item);
 		});
 	});
+
+	describe("obfuscateJSONValues", () => {
+		it("should obfuscate all fields except those in txmaFieldsToShow", async () => {
+			const inputObject = {
+				field1: "sensitive1",
+				field2: "sensitive2",
+				field3: "non-sensitive",
+				nested: {
+					field4: "sensitive3",
+					field5: "non-sensitive",
+					field6: null,
+					field7: undefined,
+				},
+			};
+	
+			const txmaFieldsToShow = ["field3", "field5"];
+	
+			const obfuscatedObject = await iprService.obfuscateJSONValues(inputObject, txmaFieldsToShow);
+	
+			// Check that sensitive fields are obfuscated and non-sensitive fields are not
+			expect(obfuscatedObject.field1).toBe("***");
+			expect(obfuscatedObject.field2).toBe("***");
+			expect(obfuscatedObject.field3).toBe("non-sensitive");
+			expect(obfuscatedObject.nested.field4).toBe("***");
+			expect(obfuscatedObject.nested.field5).toBe("non-sensitive");
+			expect(obfuscatedObject.nested.field6).toBe(null);
+			expect(obfuscatedObject.nested.field7).toBe(undefined);
+		});
+	
+		it("should handle arrays correctly", async () => {
+			const inputObject = {
+				field1: "sensitive1",
+				arrayField: [
+					{
+						field2: "sensitive2",
+						field3: "non-sensitive",
+					},
+					{
+						field2: "sensitive3",
+						field3: "non-sensitive",
+					},
+				],
+			};
+	
+			const txmaFieldsToShow = ["field3"];
+	
+			const obfuscatedObject = await iprService.obfuscateJSONValues(inputObject, txmaFieldsToShow);
+	
+			// Check that sensitive fields are obfuscated and non-sensitive fields are not
+			expect(obfuscatedObject.field1).toBe("***");
+			expect(obfuscatedObject.arrayField[0].field2).toBe("***");
+			expect(obfuscatedObject.arrayField[0].field3).toBe("non-sensitive");
+			expect(obfuscatedObject.arrayField[1].field2).toBe("***");
+			expect(obfuscatedObject.arrayField[1].field3).toBe("non-sensitive");
+		});
+	
+		it("should obfuscate values of different types", async () => {
+			const inputObject = {
+				stringField: "sensitive-string",
+				numberField: 42,
+				booleanField: true,
+			};
+	
+			const txmaFieldsToShow: string[] | undefined = [];
+	
+			const obfuscatedObject = await iprService.obfuscateJSONValues(inputObject, txmaFieldsToShow);
+	
+			// Check that all fields are obfuscated
+			expect(obfuscatedObject.stringField).toBe("***");
+			expect(obfuscatedObject.numberField).toBe("***");
+			expect(obfuscatedObject.booleanField).toBe("***");
+		});
+	
+		it('should return "***" for non-object input', async () => {
+			const input = "string-input";
+	
+			const obfuscatedValue = await iprService.obfuscateJSONValues(input);
+	
+			// Check that non-object input is obfuscated as '***'
+			expect(obfuscatedValue).toBe("***");
+		});
+	});
 });

--- a/src/tests/unit/services/IPRService.test.ts
+++ b/src/tests/unit/services/IPRService.test.ts
@@ -258,8 +258,8 @@ describe("IPR Service", () => {
 			expect(obfuscatedObject.field3).toBe("non-sensitive");
 			expect(obfuscatedObject.nested.field4).toBe("***");
 			expect(obfuscatedObject.nested.field5).toBe("non-sensitive");
-			expect(obfuscatedObject.nested.field6).toBe(null);
-			expect(obfuscatedObject.nested.field7).toBe(undefined);
+			expect(obfuscatedObject.nested.field6).toBeNull();
+			expect(obfuscatedObject.nested.field7).toBeUndefined();
 		});
 	
 		it("should handle arrays correctly", async () => {

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -35,7 +35,7 @@ describe("PostEventProcessor", () => {
 		// @ts-ignore
 		postEventProcessor.iprService = mockIprService;
 		mockIprService.saveEventData.mockResolvedValueOnce();
-		mockIprService.obfuscateJSONValues.mockResolvedValue({"event_name":"IPR_RESULT_NOTIFICATION_EMAILED","user":{"user_id":"***"},"timestamp":"***"});
+		mockIprService.obfuscateJSONValues.mockResolvedValue({ "event_name":"IPR_RESULT_NOTIFICATION_EMAILED", "user":{ "user_id":"***" }, "timestamp":"***" });
 	});
 
 	it("Returns success response when call to save event data is successful", async () => {

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -35,6 +35,7 @@ describe("PostEventProcessor", () => {
 		// @ts-ignore
 		postEventProcessor.iprService = mockIprService;
 		mockIprService.saveEventData.mockResolvedValueOnce();
+		mockIprService.obfuscateJSONValues.mockResolvedValue({"event_name":"IPR_RESULT_NOTIFICATION_EMAILED","user":{"user_id":"***"},"timestamp":"***"});
 	});
 
 	it("Returns success response when call to save event data is successful", async () => {
@@ -189,7 +190,7 @@ describe("PostEventProcessor", () => {
 			expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-4444", "SET readyToResumeOn = :readyToResumeOn, nameParts = :nameParts", { ":readyToResumeOn": 1681902001, ":nameParts": [{ "type": "GivenName", "value": "ANGELA" }, { "type": "GivenName", "value": "ZOE" }, { "type":"FamilyName", "value":"UK SPECIMEN" }] });
 			// Check if it logs about docExpiryDate missing
 			// eslint-disable-next-line @typescript-eslint/unbound-method
-			expect(mockLogger.info).toHaveBeenNthCalledWith(2, "No docExpiryDate in IPV_F2F_CRI_VC_CONSUMED event");
+			expect(mockLogger.info).toHaveBeenNthCalledWith(3, "No docExpiryDate in IPV_F2F_CRI_VC_CONSUMED event");
 		});
 
 		it("Throws error if restricted is missing", async () => {
@@ -340,7 +341,7 @@ describe("PostEventProcessor", () => {
 			// eslint-disable-next-line @typescript-eslint/unbound-method
 			expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-4444", "SET journeyWentAsyncOn = :journeyWentAsyncOn, expiresOn = :expiresOn, documentType = :documentType, clientSessionId = :clientSessionId", { ":journeyWentAsyncOn": 1681902001, ":expiresOn": expiresOn, ":documentType": "PASSPORT", ":clientSessionId": "asdfadsfasdf" });
 			// eslint-disable-next-line @typescript-eslint/unbound-method
-			expect(mockLogger.info).toHaveBeenNthCalledWith(2, "No post_office_details in F2F_YOTI_START event");
+			expect(mockLogger.info).toHaveBeenNthCalledWith(3, "No post_office_details in F2F_YOTI_START event");
 		});
 
 		it("Logs if post_office_details and document_details is missing", async () => {
@@ -349,9 +350,9 @@ describe("PostEventProcessor", () => {
 			// eslint-disable-next-line @typescript-eslint/unbound-method
 			expect(mockIprService.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-4444", "SET journeyWentAsyncOn = :journeyWentAsyncOn, expiresOn = :expiresOn", { ":journeyWentAsyncOn": 1681902001, ":expiresOn": expiresOn });
 			// eslint-disable-next-line @typescript-eslint/unbound-method
-			expect(mockLogger.info).toHaveBeenNthCalledWith(2, "No post_office_details in F2F_YOTI_START event");
+			expect(mockLogger.info).toHaveBeenNthCalledWith(3, "No post_office_details in F2F_YOTI_START event");
 			// eslint-disable-next-line @typescript-eslint/unbound-method
-			expect(mockLogger.info).toHaveBeenNthCalledWith(3, "No document_details in F2F_YOTI_START event");
+			expect(mockLogger.info).toHaveBeenNthCalledWith(4, "No document_details in F2F_YOTI_START event");
 		});
 	});
 	

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -41,4 +41,6 @@ export class Constants {
     static readonly VIST_PO_EMAIL_STATIC = "VIST_PO_EMAIL_STATIC";
 
     static readonly VIST_PO_EMAIL_DYNAMIC = "VIST_PO_EMAIL_DYNAMIC";
+
+		static readonly TXMA_FIELDS_TO_SHOW = ["event_name", "documentType", "docExpiryDate"];
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Adds new method to obfuscate TxMA Events before logging them out in Splunk to diagnose reasons why in some scenarios we don't send the dynamic emails 


<img width="812" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/a746acfa-0c0a-4b9f-8e26-26eb3a0f6349">

<img width="831" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/acbcfdea-80a6-4c05-950d-147d7793c016">

<img width="764" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/0983c59a-7418-46a9-8746-d34e75a1e07e">

<img width="887" alt="image" src="https://github.com/govuk-one-login/ipvreturn-api/assets/13416125/1d6a3dad-8df4-48bd-9fc6-f5a2e9dea09c">

