### PR TITLE
KIWI-1497: Fix 4xx and 5xx error alarms with ApiId

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -514,7 +514,20 @@ Resources:
       StageName: !Ref Environment
       OpenApiVersion: 3.0.1
       AccessLogSetting:
-        Format: "$context.requestId $context.httpMethod $context.path"
+        Format: >-
+          {
+          "requestId":"$context.requestId",
+          "ip": "$context.identity.sourceIp",
+          "requestTime":"$context.requestTime",
+          "httpMethod":"$context.httpMethod",
+          "path": "$context.path",
+          "routeKey":"$context.routeKey",
+          "status":"$context.status",
+          "protocol":"$context.protocol",
+          "responseLength":"$context.responseLength",
+          "responseLatency":"$context.responseLatency",
+          "integrationLatency":"$context.integrationLatency"
+          }
         DestinationArn: !GetAtt IPVRAPIGatewayAccessLogGroup.Arn
       EndpointConfiguration:
         Type: REGIONAL
@@ -1674,7 +1687,7 @@ Resources:
               MetricName: Count
               Dimensions:
                 - Name: ApiName
-                  Value: !Sub "ipv-return-${AWS::StackName}"
+                  Value: !Sub "${AWS::StackName} - IPVR API"
             Period: 60
             Stat: Sum
         - Id: errorPercentage
@@ -1689,7 +1702,7 @@ Resources:
               MetricName: 5XXError
               Dimensions:
                 - Name: ApiName
-                  Value: !Sub "ipv-return-${AWS::StackName}"
+                  Value: !Sub "${AWS::StackName} - IPVR API"
             Period: 60
             Stat: Sum
 
@@ -1724,7 +1737,7 @@ Resources:
               MetricName: Count
               Dimensions:
                 - Name: ApiName
-                  Value: !Sub "ipv-return-${AWS::StackName}"
+                  Value: !Sub "${AWS::StackName} - IPVR API"
             Period: 60
             Stat: Sum
         - Id: errorPercentage
@@ -1739,7 +1752,7 @@ Resources:
               MetricName: 5XXError
               Dimensions:
                 - Name: ApiName
-                  Value: !Sub "ipv-return-${AWS::StackName}"
+                  Value: !Sub "${AWS::StackName} - IPVR API"
             Period: 60
             Stat: Sum
 
@@ -1774,7 +1787,7 @@ Resources:
               MetricName: Count
               Dimensions:
                 - Name: ApiName
-                  Value: !Sub "ipv-return-${AWS::StackName}"
+                  Value: !Sub "${AWS::StackName} - IPVR API"
                 - Name: Resource
                   Value: /session
                 - Name: Stage
@@ -1795,7 +1808,7 @@ Resources:
               MetricName: 5XXError
               Dimensions:
                 - Name: ApiName
-                  Value: !Sub "ipv-return-${AWS::StackName}"
+                  Value: !Sub "${AWS::StackName} - IPVR API"
                 - Name: Resource
                   Value: /session
                 - Name: Stage
@@ -1836,7 +1849,7 @@ Resources:
               MetricName: Count
               Dimensions:
                 - Name: ApiName
-                  Value: !Sub "ipv-return-${AWS::StackName}"
+                  Value: !Sub "${AWS::StackName} - IPVR API"
                 - Name: Resource
                   Value: /session
                 - Name: Stage
@@ -1857,7 +1870,7 @@ Resources:
               MetricName: 5XXError
               Dimensions:
                 - Name: ApiName
-                  Value: !Sub "ipv-return-${AWS::StackName}"
+                  Value: !Sub "${AWS::StackName} - IPVR API"
                 - Name: Resource
                   Value: /session
                 - Name: Stage
@@ -1901,7 +1914,7 @@ Resources:
               MetricName: Count
               Dimensions:
                 - Name: ApiName
-                  Value: !Sub "ipv-return-${AWS::StackName}"
+                  Value: !Sub "${AWS::StackName} - IPVR API"
                 - Name: Resource
                   Value: /session
                 - Name: Stage
@@ -1922,7 +1935,7 @@ Resources:
               MetricName: 4XXError
               Dimensions:
                 - Name: ApiName
-                  Value: !Sub "ipv-return-${AWS::StackName}"
+                  Value: !Sub "${AWS::StackName} - IPVR API"
                 - Name: Resource
                   Value: /session
                 - Name: Stage
@@ -1963,7 +1976,7 @@ Resources:
               MetricName: Count
               Dimensions:
                 - Name: ApiName
-                  Value: !Sub "ipv-return-${AWS::StackName}"
+                  Value: !Sub "${AWS::StackName} - IPVR API"
             Period: 60
             Stat: Sum
         - Id: maxLatency
@@ -1974,7 +1987,7 @@ Resources:
               MetricName: Latency
               Dimensions:
                 - Name: ApiName
-                  Value: !Sub "ipv-return-${AWS::StackName}"
+                  Value: !Sub "${AWS::StackName} - IPVR API"
             Period: 60
             Stat: Maximum
 


### PR DESCRIPTION
- Existing 4xx and 5xx alarms does not create invocations and errors.

## Proposed changes
- ApiName is configured wrong due to which invocations does not happen
- Add Accesslogsettings to send more metrics

### What changed
- Modified access log settings on the API Gateway.
- Modified API Name confgiuration.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
- ApiName configured incorrect causes a issue with getting invocations
- Accesslogsettings require additinal parameters to alerts

### Issue tracking
- [KIWI-1497](https://govukverify.atlassian.net/browse/KIWI-1497)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[KIWI-1457]: https://govukverify.atlassian.net/browse/KIWI-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KIWI-1497]: https://govukverify.atlassian.net/browse/KIWI-1497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
![Screenshot 2024-01-15 at 11 31 43](https://github.com/govuk-one-login/ipvreturn-api/assets/131283983/055118a4-3e58-4054-b70a-4bfd7e4a2d41)

