### PR TITLE
[KIWI-1597] Appending requestId to IPR SessionHandler

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -109,7 +109,7 @@ Mappings:
       GOVUKNOTIFYTEMPLATEID: "3baf3b59-2396-44c8-b7a4-b5a981fad5e8"
       GOVUKNOTIFYDYNAMICEMAILTEMPLATEID: "fc1a7e2f-5186-4cb8-a8e0-81110b4e9e85"
       GOVUKNOTIFYFALLBACKMAILTEMPLATEID: "504a35f3-56f9-42f8-965c-cad58ff9b816"
-      GOVUKNOTIFYAPI: "https://ipvr-gov-notify-stub-govnotifystub.return.dev.account.gov.uk/govnotify"
+      GOVUKNOTIFYAPI: "https://api.notifications.service.gov.uk"
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
       TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
       RETURNJOURNEYURL: "https://return.dev.account.gov.uk/resume"

--- a/src/SessionHandler.ts
+++ b/src/SessionHandler.ts
@@ -51,6 +51,7 @@ class Session implements LambdaInterface {
 								return new Response(HttpCodesEnum.SERVER_ERROR, "An error has occurred");
 							}
 						}
+						logger.appendKeys({ requestId: event.requestContext.requestId });
 						return await SessionProcessor.getInstance(logger, metrics, CLIENT_ID).processRequest(event);
 					} catch (error) {
 						logger.error({ message: "An error has occurred. ",

--- a/src/services/SessionProcessor.ts
+++ b/src/services/SessionProcessor.ts
@@ -84,7 +84,6 @@ export class SessionProcessor {
 				return new Response(HttpCodesEnum.UNAUTHORIZED, "Invalid request: Rejected jwt");
 			}
 			const jwtIdTokenPayload: JwtPayload = parsedIdTokenJwt.payload;
-			this.logger.info("---idToken payload: ", { jwtIdTokenPayload });
 
 			// idToken Validation
 			try {
@@ -205,9 +204,6 @@ export class SessionProcessor {
 			throw new AppError(HttpCodesEnum.UNAUTHORIZED, "Failed to sign the client_assertion Jwt");
 		}
 
-		this.logger.info("---clientAssertion: ", { client_assertion })
-		this.logger.info("----authCode: " , authCode);
-
 		const ENCODED_REDIRECT_URI = encodeURIComponent(this.environmentVariables.returnRedirectUrl());
 		const ENCODED_CLIENT_ASSERTION_TYPE = encodeURIComponent(Constants.CLIENT_ASSERTION_TYPE);
 		const urlEncodedBody = `grant_type=${Constants.GRANT_TYPE}&code=${authCode}&redirect_uri=${ENCODED_REDIRECT_URI}&client_assertion_type=${ENCODED_CLIENT_ASSERTION_TYPE}&client_assertion=${client_assertion}`;
@@ -218,7 +214,6 @@ export class SessionProcessor {
 				urlEncodedBody,
 				{ headers:{ "Content-Type" : "text/plain" } },
 			);
-			this.logger.debug({ message: "Expiration time for assumedRole: ", expTime: data.expires_in });
 			return data.id_token;
 		} catch (error) {
 			this.logger.error("An error occurred when fetching OIDC token response", {

--- a/src/services/SessionProcessor.ts
+++ b/src/services/SessionProcessor.ts
@@ -84,6 +84,7 @@ export class SessionProcessor {
 				return new Response(HttpCodesEnum.UNAUTHORIZED, "Invalid request: Rejected jwt");
 			}
 			const jwtIdTokenPayload: JwtPayload = parsedIdTokenJwt.payload;
+			this.logger.info("---idToken payload: ", { jwtIdTokenPayload });
 
 			// idToken Validation
 			try {
@@ -203,6 +204,9 @@ export class SessionProcessor {
 			});
 			throw new AppError(HttpCodesEnum.UNAUTHORIZED, "Failed to sign the client_assertion Jwt");
 		}
+
+		this.logger.info("---clientAssertion: ", { client_assertion })
+		this.logger.info("----authCode: " , authCode);
 
 		const ENCODED_REDIRECT_URI = encodeURIComponent(this.environmentVariables.returnRedirectUrl());
 		const ENCODED_CLIENT_ASSERTION_TYPE = encodeURIComponent(Constants.CLIENT_ASSERTION_TYPE);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Appending requestId to IPR SessionHandler in order to trace a session request in production.

### Why did it change

To troubleshoot and further investigate KIWI-1597, we need to be able to trace a session to understand the timelines for that incoming request which results into token expiry error.

Attaching a screenshot of the dev logs for reference;
<img width="1101" alt="Screenshot 2024-02-15 at 16 10 37" src="https://github.com/govuk-one-login/ipvreturn-api/assets/115095929/c46ffcbd-6d18-477f-be80-320ba778c661">


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1597](https://govukverify.atlassian.net/browse/KIWI-1597)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

