### PR TITLE
IPS-593: Update TxMA Retention period and visibility timeout

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -111,7 +111,7 @@ Mappings:
       GOVUKNOTIFYFALLBACKMAILTEMPLATEID: "504a35f3-56f9-42f8-965c-cad58ff9b816"
       GOVUKNOTIFYAPI: "https://ipvr-gov-notify-stub-govnotifystub.return.dev.account.gov.uk/govnotify"
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
-      TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
+      TXMAMESSAGERETENTIONPERIODDAYS: 1209600 # Default: 14 days
       RETURNJOURNEYURL: "https://return.dev.account.gov.uk/resume"
       SESSIONRETURNRECORDTTLINSECS: 950400 # Default 11 days
       INITIALSESSIONRECORDTTLINSECS: 43200 # Default 12hrs
@@ -125,7 +125,7 @@ Mappings:
       GOVUKNOTIFYFALLBACKMAILTEMPLATEID: "504a35f3-56f9-42f8-965c-cad58ff9b816"
       GOVUKNOTIFYAPI: "https://govnotifystub.return.build.account.gov.uk/govnotify"
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
-      TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
+      TXMAMESSAGERETENTIONPERIODDAYS: 1209600 # Default: 14 days
       RETURNJOURNEYURL: "https://return.build.account.gov.uk/resume"
       SESSIONRETURNRECORDTTLINSECS: 950400 # Default 11 days
       INITIALSESSIONRECORDTTLINSECS: 43200 # Default 12hrs
@@ -139,7 +139,7 @@ Mappings:
       GOVUKNOTIFYFALLBACKMAILTEMPLATEID: "504a35f3-56f9-42f8-965c-cad58ff9b816"
       GOVUKNOTIFYAPI: "https://api.notifications.service.gov.uk"
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
-      TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
+      TXMAMESSAGERETENTIONPERIODDAYS: 1209600 # Default: 14 days
       RETURNJOURNEYURL: "https://return.staging.account.gov.uk/resume"
       SESSIONRETURNRECORDTTLINSECS: 950400 # Default 11 days
       INITIALSESSIONRECORDTTLINSECS: 43200 # Default 12hrs
@@ -152,7 +152,7 @@ Mappings:
       GOVUKNOTIFYFALLBACKMAILTEMPLATEID: "504a35f3-56f9-42f8-965c-cad58ff9b816"
       GOVUKNOTIFYAPI: "https://api.notifications.service.gov.uk"
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
-      TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
+      TXMAMESSAGERETENTIONPERIODDAYS: 1209600 # Default: 14 days
       RETURNJOURNEYURL: "https://return.integration.account.gov.uk/resume"
       SESSIONRETURNRECORDTTLINSECS: 950400 # Default 11 days
       INITIALSESSIONRECORDTTLINSECS: 43200 # Default 12hrs
@@ -165,7 +165,7 @@ Mappings:
       GOVUKNOTIFYFALLBACKMAILTEMPLATEID: "b1f0f510-7501-4e49-b5d4-aced6e36ad90"
       GOVUKNOTIFYAPI: "https://api.notifications.service.gov.uk"
       MESSAGERETENTIONPERIODDAYS: 345600 # Default: 4 days
-      TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
+      TXMAMESSAGERETENTIONPERIODDAYS: 1209600 # Default: 14 days
       RETURNJOURNEYURL: "https://return.account.gov.uk/resume"
       SESSIONRETURNRECORDTTLINSECS: 950400 # Default 11 days
       INITIALSESSIONRECORDTTLINSECS: 43200 # Default 12hrs
@@ -1486,7 +1486,7 @@ Resources:
           !Ref Environment,
           TXMAMESSAGERETENTIONPERIODDAYS,
         ]
-      VisibilityTimeout: 60
+      VisibilityTimeout: 70
       KmsMasterKeyId: !Ref MockTxMAKeyAlias
       RedrivePolicy:
         deadLetterTargetArn:
@@ -1573,7 +1573,7 @@ Resources:
           !Ref Environment,
           TXMAMESSAGERETENTIONPERIODDAYS,
         ]
-      VisibilityTimeout: 60
+      VisibilityTimeout: 70
       KmsMasterKeyId: !Ref TxMAKeyAlias
       RedrivePolicy:
         deadLetterTargetArn:


### PR DESCRIPTION
TxMa did a recent load test where they encountered some issues. To fix the issues they have mentioned that all teams using their service and producing events to update their SQS Queues.

## Proposed changes
- Update Message retention period to 14 days and Message Visibility timeout to 70seconds 

### What changed

Message Retention Period - 7 days to 14 days
Message Visibility Timeout - 60 Seconds to 70 Seconds

### Why did it change

Found issues with TxMA Load tests

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-593](https://govukverify.atlassian.net/browse/IPS-593)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
