### PR TITLE
KIWI-1625: Add ms to txma events

### DIFF
--- a/run-tests-locally.sh
+++ b/run-tests-locally.sh
@@ -35,5 +35,5 @@ then
     docker run --env-file docker_vars.env -v $(pwd)/results:/results $DockerImageName
 else    
     echo "Please ensure you've got a stack name as the first argument after ./run_tests_locally.sh..."
-    echo "E.g. ./run_tests_locally.sh cri-cic-api"
+    echo "E.g. ./run-tests-locally.sh ipvreturn-api"
 fi

--- a/src/models/ReturnSQSEvent.ts
+++ b/src/models/ReturnSQSEvent.ts
@@ -9,6 +9,7 @@ export interface ReturnSQSEvent {
 	clientLandingPageUrl?: string;
 	event_name: EventType;
 	timestamp: number;
+	event_timestamp_ms: number;
 	timestamp_formatted: string;
 	user: {
 		govuk_signin_journey_id?: string;

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -53,6 +53,7 @@ export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT: ReturnSQSEvent =
 	event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
 	// rp_name: "replay",
 	timestamp: 1681902001,
+	event_timestamp_ms: 1681902001713,
 	timestamp_formatted: "2023-04-19T11:00:01.000Z",
 	user: {
 		user_id: "01333e01-dde3-412f-a484-5555",
@@ -90,6 +91,7 @@ export const VALID_F2F_YOTI_START_TXMA_EVENT: ReturnSQSEvent = {
 	"client_id": "ekwU",
 	"event_name": "F2F_YOTI_START",
 	"timestamp": 1681902001,
+	"event_timestamp_ms": 1681902001713,
 	"timestamp_formatted": "2023-04-19T11:00:01.000Z",
 	"user": {
 		"user_id": "01333e01-dde3-412f-a484-4444",
@@ -105,6 +107,7 @@ export const VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT: ReturnSQSEvent = {
 	"event_name": "IPV_F2F_CRI_VC_CONSUMED",
 	"clientLandingPageUrl": "REDIRECT_URL",
 	"timestamp": 1681902001,
+	"event_timestamp_ms": 1681902001713,
 	"timestamp_formatted": "2023-04-19T11:00:01.000Z",
 	"user": {
 		"user_id": "01333e01-dde3-412f-a484-4444",
@@ -137,6 +140,7 @@ export const VALID_IPV_F2F_CRI_VC_CONSUMED_WITH_DOC_EXPIRYDATE_TXMA_EVENT: Retur
 	"event_name": "IPV_F2F_CRI_VC_CONSUMED",
 	"clientLandingPageUrl": "REDIRECT_URL",
 	"timestamp": 1681902001,
+	"event_timestamp_ms": 1681902001713,
 	"timestamp_formatted": "2023-04-19T11:00:01.000Z",
 	"user": {
 		"user_id": "01333e01-dde3-412f-a484-4444",
@@ -200,6 +204,7 @@ export const VALID_F2F_DOCUMENT_UPLOADED_TXMA_EVENT: ReturnSQSEvent = {
 	"client_id": "ekwU",
 	"event_name": "F2F_DOCUMENT_UPLOADED",
 	"timestamp": 1681902001,
+	"event_timestamp_ms": 1681902001713,
 	"timestamp_formatted": "2023-04-19T11:00:01.000Z",
 	"user": {
 		"user_id": "01333e01-dde3-412f-a484-4444",
@@ -219,6 +224,7 @@ export const VALID_F2F_YOTI_START_WITH_PO_DOC_DETAILS_TXMA_EVENT: ReturnSQSEvent
 	"client_id": "ekwU",
 	"event_name": "F2F_YOTI_START",
 	"timestamp": 1681902001,
+	"event_timestamp_ms": 1681902001713,
 	"timestamp_formatted": "2023-04-19T11:00:01.000Z",
 	"user": {
 		"user_id": "01333e01-dde3-412f-a484-4444",

--- a/src/tests/unit/services/IPRService.test.ts
+++ b/src/tests/unit/services/IPRService.test.ts
@@ -36,6 +36,7 @@ function getTXMAEventPayload(): TxmaEvent {
 			user_id: "sessionCliendId",
 		},
 		timestamp: 123,
+		event_timestamp_ms: 123000,
 	};
 	return txmaEventPayload;
 }

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -134,6 +134,7 @@ describe("PostEventProcessor", () => {
 				clientLandingPageUrl: "REDIRECT_URL",
 				event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
 				timestamp: 1681902001,
+				event_timestamp_ms: 1681902001713,
 				timestamp_formatted: "2023-04-19T11:00:01.000Z",
 				user: {
 					user_id: "01333e01-dde3-412f-a484-5555",
@@ -151,6 +152,7 @@ describe("PostEventProcessor", () => {
 				client_id: "ekwU",
 				event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
 				timestamp: 1681902001,
+				event_timestamp_ms: 1681902001713,
 				timestamp_formatted: "2023-04-19T11:00:01.000Z",
 				user: {
 					user_id: "01333e01-dde3-412f-a484-5555",
@@ -170,6 +172,7 @@ describe("PostEventProcessor", () => {
 				clientLandingPageUrl: "  ",
 				event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
 				timestamp: 1681902001,
+				event_timestamp_ms: 1681902001713,
 				timestamp_formatted: "2023-04-19T11:00:01.000Z",
 				user: {
 					user_id: "01333e01-dde3-412f-a484-5555",

--- a/src/tests/unit/services/SendEmailProcessor.test.ts
+++ b/src/tests/unit/services/SendEmailProcessor.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
@@ -8,7 +9,6 @@ import { SendEmailService } from "../../../services/SendEmailService";
 import { IPRService } from "../../../services/IPRService";
 import { mock } from "jest-mock-extended";
 import { EmailResponse } from "../../../models/EmailResponse";
-import { absoluteTimeNow } from "../../../utils/DateTimeUtils";
 import { ExtSessionEvent, SessionEvent } from "../../../models/SessionEvent";
 import { Email, DynamicEmail } from "../../../models/Email";
 import { Constants } from "../../../utils/Constants";
@@ -122,10 +122,16 @@ describe("SendEmailProcessor", () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date(1585695600000));
 		sqsEvent = VALID_GOV_NOTIFY_HANDLER_SQS_EVENT;
 		sqsEventNewEmail = VALID_GOV_NOTIFY_HANDLER_SQS_EVENT_DYNAMIC_EMAIL;
 		mockSessionEvent = getMockSessionEventItem();
 		mockExtSessionEvent = getMockExtSessionEventItem();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
 	});
 
 	it("Returns success response when all required Email attributes exists to send static template Email messageType", async () => {
@@ -143,7 +149,8 @@ describe("SendEmailProcessor", () => {
 		expect(mockIprService.sendToTXMA).toHaveBeenCalledTimes(1);
 		expect(mockIprService.sendToTXMA).toHaveBeenCalledWith({
 			event_name: "IPR_RESULT_NOTIFICATION_EMAILED",
-			timestamp: absoluteTimeNow(),
+			timestamp: 1585695600,
+			event_timestamp_ms: 1585695600000,
 			user: {
 				email: "test.user@digital.cabinet-office.gov.uk",
 				user_id: "user_id",
@@ -278,7 +285,8 @@ describe("SendEmailProcessor", () => {
 		expect(mockIprService.sendToTXMA).toHaveBeenCalledTimes(1);
 		expect(mockIprService.sendToTXMA).toHaveBeenCalledWith({
 			event_name: "IPR_RESULT_NOTIFICATION_EMAILED",
-			timestamp: absoluteTimeNow(),
+			timestamp: 1585695600,
+			event_timestamp_ms: 1585695600000,
 			user: {
 				email: "test.user@digital.cabinet-office.gov.uk",
 				user_id: "user_id",
@@ -317,7 +325,8 @@ describe("SendEmailProcessor", () => {
 		expect(mockIprService.sendToTXMA).toHaveBeenCalledTimes(1);
 		expect(mockIprService.sendToTXMA).toHaveBeenCalledWith({
 			event_name: "IPR_RESULT_NOTIFICATION_EMAILED",
-			timestamp: absoluteTimeNow(),
+			timestamp: 1585695600,
+			event_timestamp_ms: 1585695600000,
 			user: {
 				email: "test.user@digital.cabinet-office.gov.uk",
 				user_id: "user_id",

--- a/src/tests/unit/utils/Txma.test.ts
+++ b/src/tests/unit/utils/Txma.test.ts
@@ -1,21 +1,34 @@
 import { buildCoreEventFields } from "../../../utils/TxmaEvent";
 
-const timestamp = 1687181105;
 const user_id = "userId";
 const email = "test@test.com";
 
-jest.mock("../../../utils/DateTimeUtils", () => ({
-	absoluteTimeNow: () => timestamp,
-}));
-
 describe("TxmaEvents", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date(1585695600000));
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
 	describe("buildCoreEventFields", () => {
 		it("Returns object with default values user and timestamp", () => {
-			expect(buildCoreEventFields({ user_id })).toEqual({ user: { user_id }, timestamp });
+			expect(buildCoreEventFields({ user_id })).toEqual({
+				user: { user_id },
+				timestamp: 1585695600,
+				event_timestamp_ms: 1585695600000,
+			});
 		});
 
 		it("Returns object with user with email if provided", () => {
-			expect(buildCoreEventFields({ user_id, email })).toEqual({ user: { user_id, email }, timestamp });
+			expect(buildCoreEventFields({ user_id, email })).toEqual({
+				user: { user_id, email },
+				timestamp: 1585695600,
+				event_timestamp_ms: 1585695600000,
+			});
 		});
 	});
 });

--- a/src/utils/TxmaEvent.ts
+++ b/src/utils/TxmaEvent.ts
@@ -1,5 +1,3 @@
-import { absoluteTimeNow } from "./DateTimeUtils";
-
 export type TxmaEventName =
 	"IPR_RESULT_NOTIFICATION_EMAILED"
 	| "IPR_USER_REDIRECTED";
@@ -14,6 +12,7 @@ export interface TxmaUser {
 export interface BaseTxmaEvent {
 	"user"?: TxmaUser;
 	"timestamp": number;
+	"event_timestamp_ms": number;
 }
 
 export interface ExtensionObject {
@@ -25,11 +24,14 @@ export interface TxmaEvent extends BaseTxmaEvent {
 	"extensions"?: ExtensionObject;
 }
 
-export const buildCoreEventFields = (user: TxmaUser, getNow: () => number = absoluteTimeNow): BaseTxmaEvent => {
+export const buildCoreEventFields = (user: TxmaUser): BaseTxmaEvent => {
+	const now = Date.now();
+
 	return {
 		user: {
 			...user,
 		},
-		timestamp: getNow(),
+		timestamp: Math.floor(now / 1000),
+		event_timestamp_ms: now,
 	};
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

 adds event_timestamp_ms to TXMA events

### Why did it change

to provide more granularity

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1625](https://govukverify.atlassian.net/browse/KIWI-1625)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[KIWI-1625]: https://govukverify.atlassian.net/browse/KIWI-1625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ