### PR TITLE
KIWI-1756 - Check SESSION_EVENTS_TABLE after F2F_YOTI_START Event

### DIFF
--- a/src/tests/api/postEventStream.test.ts
+++ b/src/tests/api/postEventStream.test.ts
@@ -19,7 +19,48 @@ describe("post event processor", () => {
 		console.log("userId: ", userId);
 	});
 
-	it("when all 3 events are sent, a Dynamo record with the details of all three events populated", async () => {
+	it("when AUTH_IPV_AUTHORISATION_REQUESTED and F2F_YOTI_START events are sent, a Dynamo record with the details of both events is recorded", async () => {
+		await postMockEvent(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT, userId, true);
+		await postMockEvent(VALID_F2F_YOTI_START_WITH_PO_DOC_DETAILS_TXMA_EVENT, userId, false);
+		
+		const response = await getSessionByUserId(userId, constants.API_TEST_SESSION_EVENTS_TABLE!);
+
+		expect(response?.clientName).toBe("ekwU");
+		expect(response?.redirectUri).toBe("REDIRECT_URL");
+		expect(response?.userEmail).toBe(constants.API_TEST_EMAIL_ADDRESS);
+		expect(response?.documentType).toBe("PASSPORT");
+		expect(response?.postOfficeInfo).toEqual([
+			{
+				"M": {
+					"address": {
+						"S": "1 The Street, Funkytown",
+					},
+					"location": {
+						"L": [
+							{
+								"M": {
+									"latitude": {
+										"N": "0.34322",
+									},
+									"longitude": {
+										"N": "-42.48372",
+									},
+								},
+							},
+						],
+					},
+					"name": {
+						"S": "Post Office Name",
+					},
+					"post_code": {
+						"S": "N1 2AA",
+					},
+				},
+			},
+		]);
+	}, 20000); 
+
+	it("when all 4 events are sent, a Dynamo record with the details of all 4 events is recorded", async () => {
 		await postMockEvent(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT, userId, true);
 		await postMockEvent(VALID_F2F_YOTI_START_WITH_PO_DOC_DETAILS_TXMA_EVENT, userId, false);
 		await postMockEvent(VALID_F2F_DOCUMENT_UPLOADED_TXMA_EVENT, userId, false);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Add test to check SESSION_EVENTS_TABLE after F2F_YOTI_START Event
Send the following 2 events - VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT, VALID_F2F_YOTI_START_WITH_PO_DOC_DETAILS_TXMA_EVENT

Validate the following sessionEvents dynamoDB fields: 

- clientName
- redirectUri
- userEmail
- documentType
- postOfficeInfo


### Why did it change

Test changes to IPR BE to Improve performance with Auth events table

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1756](https://govukverify.atlassian.net/browse/KIWI-1756)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-1756]: https://govukverify.atlassian.net/browse/KIWI-1756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ