### PR TITLE
[KIWI-1756]- IPR | BE | Improve performance with Auth events table

### DIFF
--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -99,7 +99,7 @@ export class PostEventProcessor {
 			switch (eventName) {
 				case Constants.AUTH_IPV_AUTHORISATION_REQUESTED: {
 					if (!this.checkIfValidString([userDetails.email, eventDetails.client_id])) {
-						this.logger.warn({ message: "clientLandingPageUrl empty" })
+						this.logger.warn({ message: "clientLandingPageUrl empty" });
 						this.logger.warn({ message: "Missing or invalid value for any or all of userDetails.email, eventDetails.client_id fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
 						return `Missing info in sqs ${Constants.AUTH_IPV_AUTHORISATION_REQUESTED} event, it is unlikely that this event was meant for F2F`;
 					}

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -98,8 +98,9 @@ export class PostEventProcessor {
 			const returnRecord = new SessionReturnRecord(eventDetails, expiresOn );
 			switch (eventName) {
 				case Constants.AUTH_IPV_AUTHORISATION_REQUESTED: {
-					if (!this.checkIfValidString([userDetails.email, eventDetails.client_id, eventDetails.clientLandingPageUrl])) {
-						this.logger.warn({ message: "Missing or invalid value for any or all of userDetails.email, eventDetails.client_id, eventDetails.clientLandingPageUrl fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
+					if (!this.checkIfValidString([userDetails.email, eventDetails.client_id])) {
+						this.logger.warn({ message: "clientLandingPageUrl empty" })
+						this.logger.warn({ message: "Missing or invalid value for any or all of userDetails.email, eventDetails.client_id fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
 						return `Missing info in sqs ${Constants.AUTH_IPV_AUTHORISATION_REQUESTED} event, it is unlikely that this event was meant for F2F`;
 					}
 					updateExpression = "SET ipvStartedOn = :ipvStartedOn, userEmail = :userEmail, clientName = :clientName,  redirectUri = :redirectUri, expiresOn = :expiresOn";

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -160,7 +160,7 @@ describe("PostEventProcessor", () => {
 			expect(mockLogger.warn).toHaveBeenCalledWith({ message: "Missing or invalid value for any or all of userDetails.email, eventDetails.client_id fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
 			expect(result).toBe(`Missing info in sqs ${Constants.AUTH_IPV_AUTHORISATION_REQUESTED} event, it is unlikely that this event was meant for F2F`);
 		});
-
+	});
 
 	describe("IPV_F2F_CRI_VC_CONSUMED_EVENT event", () => {
 		it("Calls saveEventData with appropriate payload for IPV_F2F_CRI_VC_CONSUMED_EVENT event", async () => {

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -147,7 +147,6 @@ describe("PostEventProcessor", () => {
 			const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_MISSING_EMAIL: ReturnSQSEvent = {
 				event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
 				client_id: "ekwU",
-				clientLandingPageUrl: "REDIRECT_URL",
 				event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
 				timestamp: 1681902001,
 				event_timestamp_ms: 1681902001713,
@@ -158,49 +157,10 @@ describe("PostEventProcessor", () => {
 			};
 			const result = await postEventProcessorMockServices.processRequest(JSON.stringify(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_MISSING_EMAIL));
 			// eslint-disable-next-line @typescript-eslint/unbound-method
-			expect(mockLogger.warn).toHaveBeenCalledWith({ message: "Missing or invalid value for any or all of userDetails.email, eventDetails.client_id, eventDetails.clientLandingPageUrl fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
+			expect(mockLogger.warn).toHaveBeenCalledWith({ message: "Missing or invalid value for any or all of userDetails.email, eventDetails.client_id fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
 			expect(result).toBe(`Missing info in sqs ${Constants.AUTH_IPV_AUTHORISATION_REQUESTED} event, it is unlikely that this event was meant for F2F`);
 		});
 
-		it("Throws error if clientLandingPageUrl is missing", async () => {
-			const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_MISSING_LANDINGURL: ReturnSQSEvent = {
-				event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
-				client_id: "ekwU",
-				event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
-				timestamp: 1681902001,
-				event_timestamp_ms: 1681902001713,
-				timestamp_formatted: "2023-04-19T11:00:01.000Z",
-				user: {
-					user_id: "01333e01-dde3-412f-a484-4444",
-					email: "test@jest.com",
-				},
-			};
-			const result = await postEventProcessorMockServices.processRequest(JSON.stringify(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_MISSING_LANDINGURL));
-			// eslint-disable-next-line @typescript-eslint/unbound-method
-			expect(mockLogger.warn).toHaveBeenCalledWith({ message: "Missing or invalid value for any or all of userDetails.email, eventDetails.client_id, eventDetails.clientLandingPageUrl fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
-			expect(result).toBe(`Missing info in sqs ${Constants.AUTH_IPV_AUTHORISATION_REQUESTED} event, it is unlikely that this event was meant for F2F`);
-		});
-
-		it("Throws error if clientLandingPageUrl is only spaces", async () => {
-			const AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_URL_SPACES: ReturnSQSEvent = {
-				event_id: "588f4a66-f75a-4728-9f7b-8afd865c233c",
-				client_id: "ekwU",
-				clientLandingPageUrl: "  ",
-				event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
-				timestamp: 1681902001,
-				event_timestamp_ms: 1681902001713,
-				timestamp_formatted: "2023-04-19T11:00:01.000Z",
-				user: {
-					user_id: "01333e01-dde3-412f-a484-4444",
-					email: "test@jest.com",
-				},
-			};
-			const result = await postEventProcessorMockServices.processRequest(JSON.stringify(AUTH_IPV_AUTHORISATION_REQUESTED_EVENT_URL_SPACES));
-			// eslint-disable-next-line @typescript-eslint/unbound-method
-			expect(mockLogger.warn).toHaveBeenCalledWith({ message: "Missing or invalid value for any or all of userDetails.email, eventDetails.client_id, eventDetails.clientLandingPageUrl fields required for AUTH_IPV_AUTHORISATION_REQUESTED event type" }, { messageCode: MessageCodes.MISSING_MANDATORY_FIELDS });
-			expect(result).toBe(`Missing info in sqs ${Constants.AUTH_IPV_AUTHORISATION_REQUESTED} event, it is unlikely that this event was meant for F2F`);
-		});
-	});
 
 	describe("IPV_F2F_CRI_VC_CONSUMED_EVENT event", () => {
 		it("Calls saveEventData with appropriate payload for IPV_F2F_CRI_VC_CONSUMED_EVENT event", async () => {


### PR DESCRIPTION
### What changed

Removed clientLandingPageCheck in PostEventProcessor

### Why did it change

Check was preventing events after Auth Event being processed as RP value was empty

### Issue tracking

- [KIWI-1756](https://govukverify.atlassian.net/browse/KIWI-1756)


[KIWI-1756]: https://govukverify.atlassian.net/browse/KIWI-1756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ