### PR TITLE
[KIWI-1512]Updating logs to printout the response-id when an email is sent successfully.

### DIFF
--- a/src/services/SendEmailService.ts
+++ b/src/services/SendEmailService.ts
@@ -122,7 +122,7 @@ export class SendEmailService {
     			this.logger.info("govNotify URL: " + this.environmentVariables.govukNotifyApiUrl());
     			const emailResponse = await this.govNotify.sendEmail(templateId, message.emailAddress, options);
     			this.logger.debug("sendEmail - response status after sending Email", SendEmailService.name, emailResponse.status);
-    			return new EmailResponse(new Date().toISOString(), "", emailResponse.status);
+    			return new EmailResponse(new Date().toISOString(), "", { emailResponseStatus: emailResponse.status, emailResponseId: emailResponse.data.id });
     		} catch (err: any) {
     			this.logger.error("sendEmail - GOV UK Notify threw an error");
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Log the id from the response body when an email is sent successfully

### Why did it change

Enhancing the IPR GovNotify logs for Support engineer to grab the id to further investigate the email status using the id.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1512](https://govukverify.atlassian.net/browse/KIWI-1512)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged


Evidence of the log for reference:
<img width="662" alt="Screenshot 2024-06-19 at 15 58 47" src="https://github.com/govuk-one-login/ipvreturn-api/assets/115095929/5b36fc3d-853b-45f3-9a9d-ebbea23c71ae">


[KIWI-1512]: https://govukverify.atlassian.net/browse/KIWI-1512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ