### PR TITLE
KIWI-XXX: Adding managed group kiwi admins to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # This is the CODEOWNERS file. These owners will be the default owners for everything in the di-ipvreturn-api repository
 # The following below will be requested for review when someone opens a pull request.
 
-* @govuk-one-login/kiwi-api-codeowners
+* @govuk-one-login/kiwi-api-codeowners @govuk-one-login/kiwi-admins
 
 # The following allows QA to review changes to /tests directory
 


### PR DESCRIPTION
## Proposed changes

### What changed

Added managed group admins to code owners 

### Why did it change

So that admins can merge code when required

