### PR TITLE
KIWI-1899: Added the issuer to relevant TxMA events and fixed test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ bin-release/
 /docker_vars.env
 results/
 cf-output.txt
+
+.DS_Store
+
+.idea/

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -110,6 +110,7 @@ Mappings:
 
   EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
+      ISSUER: "https://return.dev.account.gov.uk"
       GOVUKNOTIFYTEMPLATEID: "3baf3b59-2396-44c8-b7a4-b5a981fad5e8"
       GOVUKNOTIFYDYNAMICEMAILTEMPLATEID: "fc1a7e2f-5186-4cb8-a8e0-81110b4e9e85"
       GOVUKNOTIFYFALLBACKMAILTEMPLATEID: "504a35f3-56f9-42f8-965c-cad58ff9b816"
@@ -124,6 +125,7 @@ Mappings:
       RETURNREDIRECTURL: "https://return.dev.account.gov.uk/callback"
       TESTHARNESSURL: "https://ipvreturn-test-harness-testharness.return.dev.account.gov.uk"
     build:
+      ISSUER: "https://return.build.account.gov.uk"
       GOVUKNOTIFYTEMPLATEID: "3baf3b59-2396-44c8-b7a4-b5a981fad5e8"
       GOVUKNOTIFYDYNAMICEMAILTEMPLATEID: "fc1a7e2f-5186-4cb8-a8e0-81110b4e9e85"
       GOVUKNOTIFYFALLBACKMAILTEMPLATEID: "504a35f3-56f9-42f8-965c-cad58ff9b816"
@@ -138,6 +140,7 @@ Mappings:
       RETURNREDIRECTURL: "https://return.build.account.gov.uk/callback"
       TESTHARNESSURL: "https://testharness.return.build.account.gov.uk"
     staging:
+      ISSUER: "https://return.staging.account.gov.uk"
       GOVUKNOTIFYTEMPLATEID: "3baf3b59-2396-44c8-b7a4-b5a981fad5e8"
       GOVUKNOTIFYDYNAMICEMAILTEMPLATEID: "fc1a7e2f-5186-4cb8-a8e0-81110b4e9e85"
       GOVUKNOTIFYFALLBACKMAILTEMPLATEID: "504a35f3-56f9-42f8-965c-cad58ff9b816"
@@ -151,6 +154,7 @@ Mappings:
       OIDCURL: "https://oidc.staging.account.gov.uk/"
       RETURNREDIRECTURL: "https://return.staging.account.gov.uk/callback"
     integration:
+      ISSUER: "https://return.integration.account.gov.uk"
       GOVUKNOTIFYTEMPLATEID: "3baf3b59-2396-44c8-b7a4-b5a981fad5e8"
       GOVUKNOTIFYDYNAMICEMAILTEMPLATEID: "fc1a7e2f-5186-4cb8-a8e0-81110b4e9e85"
       GOVUKNOTIFYFALLBACKMAILTEMPLATEID: "504a35f3-56f9-42f8-965c-cad58ff9b816"
@@ -164,6 +168,7 @@ Mappings:
       OIDCURL: "https://oidc.integration.account.gov.uk/"
       RETURNREDIRECTURL: "https://return.integration.account.gov.uk/callback"
     production:
+      ISSUER: "https://return.account.gov.uk"
       GOVUKNOTIFYTEMPLATEID: "206971e2-d576-4d12-b34f-b0de442d39ab"
       GOVUKNOTIFYDYNAMICEMAILTEMPLATEID: "f62672d4-ff45-470e-8506-956482061f54"
       GOVUKNOTIFYFALLBACKMAILTEMPLATEID: "b1f0f510-7501-4e49-b5d4-aced6e36ad90"
@@ -306,6 +311,7 @@ Globals:
         AWS_STACK_NAME: !Sub ${AWS::StackName} # The AWS Stack Name, as passed into the template.
         POWERTOOLS_LOG_LEVEL: !If [IsNotProdLikeEnvironment, "DEBUG", "INFO"] # The LogLevel for the AWS PowerTools LogHelper
         POWERTOOLS_METRICS_NAMESPACE: IPR-CRI # The Metric Namespace for the AWS PowerTools MetricHelper
+        ISSUER: !FindInMap [EnvironmentVariables, !Ref Environment, ISSUER]
     AutoPublishAlias: live
 
 Resources:
@@ -955,6 +961,7 @@ Resources:
           GOVUKNOTIFY_API_KEY_SSM_PATH: !Sub "/${Environment}/ipvreturn-gov-notify/GOVUKNOTIFY_API_KEY"
           RETURN_JOURNEY_URL: !FindInMap [ EnvironmentVariables, !Ref Environment, RETURNJOURNEYURL ]
           TXMA_QUEUE_URL: !Ref TxMASQSQueue
+          ISSUER: !FindInMap [EnvironmentVariables, !Ref Environment, ISSUER]
           SESSION_EVENTS_TABLE:
             Fn::ImportValue: !Sub "${L2DynamoStackName}-session-events-table-name"
       Policies:

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -4,6 +4,7 @@ process.env.GOVUKNOTIFY_DYNAMIC_EMAIL_TEMPLATE_ID = "new-template-id"
 process.env.GOVUKNOTIFY_FALLBACK_EMAIL_TEMPLATE_ID = "fallback-template-id"
 process.env.GOVUKNOTIFY_API_KEY_SSM_PATH = "/dev/f2f-gov-notify/lsdkgl"
 process.env.TXMA_QUEUE_URL = "MYQUEUE"
+process.env.ISSUER = "ISSUER"
 process.env.RETURN_JOURNEY_URL = "www.test.com/return_journey_url";
 process.env.SESSION_EVENTS_TABLE = 'SessionEventsTable';
 process.env.AUTH_EVENT_TTL_SECS = '21600';

--- a/src/package.json
+++ b/src/package.json
@@ -29,7 +29,7 @@
     "notifications-node-client": "^7.0.0"
   },
   "scripts": {
-    "unit": "./node_modules/.bin/jest --testPathPattern=tests/unit --coverage",
+    "unit": "./node_modules/.bin/jest --testPathPattern=tests/unit --no-cache  --coverage",
     "test:unit": "npm run compile && npm run unit",
     "lint:fix": "eslint --fix --output-file ./reports/eslint/report.html --format html -c .eslintrc.js --ext .ts .",
     "compile": "./node_modules/.bin/tsc",
@@ -42,7 +42,7 @@
   "devDependencies": {
     "aws-cdk-lib": "^2.147.3",
     "@types/aws-lambda": "^8.10.109",
-    "@types/jest": "^29.4.0",
+    "@types/jest": "29.5.13",
     "@types/js-yaml": "^4.0.5",
     "@types/node": "^18.11.18",
     "@types/node-jose": "^1.1.10",
@@ -61,11 +61,11 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-security": "^1.6.0",
     "fast-xml-parser": "^4.2.7",
-    "jest": "^29.4.1",
-    "jest-junit": "^16.0.0",
+    "jest": "29.7.0",
+    "jest-junit": "16.0.0",
     "jest-mock-extended": "^3.0.1",
     "prettier": "^2.8.4",
-    "ts-jest": "^29.0.5",
+    "ts-jest": "29.2.5",
     "ts-node": "^10.9.1",
     "ts-standard": "^12.0.2",
     "tslint": "^6.1.3",

--- a/src/services/EnvironmentVariables.ts
+++ b/src/services/EnvironmentVariables.ts
@@ -50,168 +50,174 @@ export class EnvironmentVariables {
 
 	private readonly GOVUKNOTIFY_FALLBACK_EMAIL_TEMPLATE_ID = process.env.GOVUKNOTIFY_FALLBACK_EMAIL_TEMPLATE_ID;
 
+  	private readonly ISSUER = process.env.ISSUER;
 
-	/*
+  	/*
 	 * This function performs validation on env variable values.
 	 * If certain variables have unexpected values the constructor will throw an error and/or log an error message
 	 */
-	private verifyEnvVariablesByServiceType(serviceType: ServicesEnum, logger: Logger): void {
-		switch (serviceType) {
-			case ServicesEnum.GOV_NOTIFY_SERVICE: {
-				if (!this.GOVUKNOTIFY_API_KEY_SSM_PATH || this.GOVUKNOTIFY_API_KEY_SSM_PATH.trim().length === 0 ||
+  	private verifyEnvVariablesByServiceType(serviceType: ServicesEnum, logger: Logger): void {
+  		switch (serviceType) {
+  			case ServicesEnum.GOV_NOTIFY_SERVICE: {
+  				if (!this.GOVUKNOTIFY_API_KEY_SSM_PATH || this.GOVUKNOTIFY_API_KEY_SSM_PATH.trim().length === 0 ||
 					!this.RETURN_JOURNEY_URL || this.RETURN_JOURNEY_URL.trim().length === 0 ||
 					!this.TXMA_QUEUE_URL || this.TXMA_QUEUE_URL.trim().length === 0 ||
 					!this.SESSION_EVENTS_TABLE || this.SESSION_EVENTS_TABLE.trim().length === 0 ||
 					!this.GOVUKNOTIFY_API || this.GOVUKNOTIFY_API.trim().length === 0 ||
 					!this.GOVUKNOTIFY_DYNAMIC_EMAIL_TEMPLATE_ID || this.GOVUKNOTIFY_DYNAMIC_EMAIL_TEMPLATE_ID.trim().length === 0 ||
 					!this.GOVUKNOTIFY_TEMPLATE_ID || this.GOVUKNOTIFY_TEMPLATE_ID.trim().length === 0 ||
-					!this.GOVUKNOTIFY_FALLBACK_EMAIL_TEMPLATE_ID || this.GOVUKNOTIFY_FALLBACK_EMAIL_TEMPLATE_ID.trim().length === 0) {
-					logger.error({ message: "GovNotifyService - Misconfigured external API's key" }, { messageCode: MessageCodes.MISSING_CONFIGURATION });
-					throw new AppError(HttpCodesEnum.SERVER_ERROR, Constants.ENV_VAR_UNDEFINED);
-				}
+					!this.GOVUKNOTIFY_FALLBACK_EMAIL_TEMPLATE_ID || this.GOVUKNOTIFY_FALLBACK_EMAIL_TEMPLATE_ID.trim().length === 0 ||
+					!this.ISSUER || this.ISSUER.trim().length === 0) {
+  					logger.error({ message: "GovNotifyService - Misconfigured external API's key" }, { messageCode: MessageCodes.MISSING_CONFIGURATION });
+  					throw new AppError(HttpCodesEnum.SERVER_ERROR, Constants.ENV_VAR_UNDEFINED);
+  				}
 
-				if (!this.GOVUKNOTIFY_BACKOFF_PERIOD_MS
+  				if (!this.GOVUKNOTIFY_BACKOFF_PERIOD_MS
 					|| this.GOVUKNOTIFY_BACKOFF_PERIOD_MS.trim().length === 0
 					|| +this.GOVUKNOTIFY_BACKOFF_PERIOD_MS.trim() === 0
 					|| +this.GOVUKNOTIFY_BACKOFF_PERIOD_MS.trim() >= 60000) {
-					this.GOVUKNOTIFY_BACKOFF_PERIOD_MS = "20000";
-					logger.warn({ message:"GOVUKNOTIFY_BACKOFF_PERIOD_MS env var is not set. Setting to default - 20000" });
-				}
+  					this.GOVUKNOTIFY_BACKOFF_PERIOD_MS = "20000";
+  					logger.warn({ message:"GOVUKNOTIFY_BACKOFF_PERIOD_MS env var is not set. Setting to default - 20000" });
+  				}
 
-				if (!this.GOVUKNOTIFY_MAX_RETRIES
+  				if (!this.GOVUKNOTIFY_MAX_RETRIES
 					|| this.GOVUKNOTIFY_MAX_RETRIES.trim().length === 0
 					|| +this.GOVUKNOTIFY_MAX_RETRIES.trim() >= 100) {
-					this.GOVUKNOTIFY_MAX_RETRIES = "3";
-					logger.warn({ message: "GOVUKNOTIFY_MAX_RETRIES env var is not set. Setting to default - 3" });
-				}
-				break;
-			}
-			case ServicesEnum.POST_EVENT_SERVICE: {
-				if (!this.SESSION_EVENTS_TABLE || this.SESSION_EVENTS_TABLE.trim().length === 0 ||
+  					this.GOVUKNOTIFY_MAX_RETRIES = "3";
+  					logger.warn({ message: "GOVUKNOTIFY_MAX_RETRIES env var is not set. Setting to default - 3" });
+  				}
+  				break;
+  			}
+  			case ServicesEnum.POST_EVENT_SERVICE: {
+  				if (!this.SESSION_EVENTS_TABLE || this.SESSION_EVENTS_TABLE.trim().length === 0 ||
 					!this.SESSION_RETURN_RECORD_TTL_SECS || !this.AUTH_EVENT_TTL_SECS ) {
-					logger.error({ message: "PostEvent Handler - Missing SessionEvents Tablename or SESSION_RETURN_RECORD_TTL_SECS or INITIAL_SESSION_RECORD_TTL_SECS" }, { messageCode: MessageCodes.MISSING_CONFIGURATION });
-					throw new AppError(HttpCodesEnum.SERVER_ERROR, Constants.ENV_VAR_UNDEFINED);
-				}
-				break;
-			}
-			case ServicesEnum.STREAM_PROCESSOR_SERVICE: {
-				if (!this.GOV_NOTIFY_QUEUE_URL || this.GOV_NOTIFY_QUEUE_URL.trim().length === 0 ||
+  					logger.error({ message: "PostEvent Handler - Missing SessionEvents Tablename or SESSION_RETURN_RECORD_TTL_SECS or INITIAL_SESSION_RECORD_TTL_SECS" }, { messageCode: MessageCodes.MISSING_CONFIGURATION });
+  					throw new AppError(HttpCodesEnum.SERVER_ERROR, Constants.ENV_VAR_UNDEFINED);
+  				}
+  				break;
+  			}
+  			case ServicesEnum.STREAM_PROCESSOR_SERVICE: {
+  				if (!this.GOV_NOTIFY_QUEUE_URL || this.GOV_NOTIFY_QUEUE_URL.trim().length === 0 ||
 					!this.SESSION_EVENTS_TABLE || this.SESSION_EVENTS_TABLE.trim().length === 0) {
-					logger.error({ message: "Stream Processor Service - Misconfigured external API's key" }, { messageCode: MessageCodes.MISSING_CONFIGURATION } );
-					throw new AppError(HttpCodesEnum.SERVER_ERROR, Constants.ENV_VAR_UNDEFINED);
-				}
-				break;
-			}
-			case ServicesEnum.GET_SESSION_EVENT_DATA_SERVICE: {
-				if (!this.CLIENT_ID_SSM_PATH || this.CLIENT_ID_SSM_PATH.trim().length === 0 ||
+  					logger.error({ message: "Stream Processor Service - Misconfigured external API's key" }, { messageCode: MessageCodes.MISSING_CONFIGURATION } );
+  					throw new AppError(HttpCodesEnum.SERVER_ERROR, Constants.ENV_VAR_UNDEFINED);
+  				}
+  				break;
+  			}
+  			case ServicesEnum.GET_SESSION_EVENT_DATA_SERVICE: {
+  				if (!this.CLIENT_ID_SSM_PATH || this.CLIENT_ID_SSM_PATH.trim().length === 0 ||
 					!this.KMS_KEY_ARN || this.KMS_KEY_ARN.trim().length === 0 ||
 					!this.SESSION_EVENTS_TABLE || this.SESSION_EVENTS_TABLE.trim().length === 0 ||
 					!this.OIDC_URL || this.OIDC_URL.trim().length === 0 ||
 					!this.RETURN_REDIRECT_URL || this.RETURN_REDIRECT_URL.trim().length === 0 ||
 					!this.ASSUMEROLE_WITH_WEB_IDENTITY_ARN || this.ASSUMEROLE_WITH_WEB_IDENTITY_ARN.trim().length === 0 ||
 					!this.TXMA_QUEUE_URL || this.TXMA_QUEUE_URL.trim().length === 0) {
-					logger.error({ message: "Get Session event data Service - Misconfigured external API's key" }, { messageCode: MessageCodes.MISSING_CONFIGURATION });
-					throw new AppError(HttpCodesEnum.SERVER_ERROR, Constants.ENV_VAR_UNDEFINED);
-				}
-				if (!this.OIDC_JWT_ASSERTION_TOKEN_EXP || this.OIDC_JWT_ASSERTION_TOKEN_EXP.trim().length === 0) {
-					this.OIDC_JWT_ASSERTION_TOKEN_EXP = "900";
-					logger.warn({ message: "OIDC_JWT_ASSERTION_TOKEN_EXP env var is not set. Setting the expiry to default - 15 minutes." });
-				}
-				break;
-			}
-			default:
-				break;
-		}
-	}
+  					logger.error({ message: "Get Session event data Service - Misconfigured external API's key" }, { messageCode: MessageCodes.MISSING_CONFIGURATION });
+  					throw new AppError(HttpCodesEnum.SERVER_ERROR, Constants.ENV_VAR_UNDEFINED);
+  				}
+  				if (!this.OIDC_JWT_ASSERTION_TOKEN_EXP || this.OIDC_JWT_ASSERTION_TOKEN_EXP.trim().length === 0) {
+  					this.OIDC_JWT_ASSERTION_TOKEN_EXP = "900";
+  					logger.warn({ message: "OIDC_JWT_ASSERTION_TOKEN_EXP env var is not set. Setting the expiry to default - 15 minutes." });
+  				}
+  				break;
+  			}
+  			default:
+  				break;
+  		}
+  	}
 
-	/**
-	 * Constructor reads all necessary environment variables by ServiceType
-	 */
-	constructor(logger: Logger, serviceType: ServicesEnum) {
-		this.verifyEnvVariablesByServiceType(serviceType, logger);
-	}
+  	/**
+    * Constructor reads all necessary environment variables by ServiceType
+    */
+  	constructor(logger: Logger, serviceType: ServicesEnum) {
+  		this.verifyEnvVariablesByServiceType(serviceType, logger);
+  	}
 
-	/**
-	 * Accessor methods for env variable values
-	 */
+  	/**
+    * Accessor methods for env variable values
+    */
 
-	getEmailTemplateId(): any {
-		return this.GOVUKNOTIFY_TEMPLATE_ID;
-	}
+  	getEmailTemplateId(): any {
+  		return this.GOVUKNOTIFY_TEMPLATE_ID;
+  	}
 
-	getDynamicEmailTemplateId(): any {
-		return this.GOVUKNOTIFY_DYNAMIC_EMAIL_TEMPLATE_ID;
-	}
+  	getDynamicEmailTemplateId(): any {
+  		return this.GOVUKNOTIFY_DYNAMIC_EMAIL_TEMPLATE_ID;
+  	}
 
-	maxRetries(): number {
-		return +this.GOVUKNOTIFY_MAX_RETRIES!;
-	}
+  	maxRetries(): number {
+  		return +this.GOVUKNOTIFY_MAX_RETRIES!;
+  	}
 
-	backoffPeriod(): number {
-		return +this.GOVUKNOTIFY_BACKOFF_PERIOD_MS!;
-	}
+  	backoffPeriod(): number {
+  		return +this.GOVUKNOTIFY_BACKOFF_PERIOD_MS!;
+  	}
 
-	govNotifyApiKeySsmPath(): any {
-		return this.GOVUKNOTIFY_API_KEY_SSM_PATH;
-	}
+  	govNotifyApiKeySsmPath(): any {
+  		return this.GOVUKNOTIFY_API_KEY_SSM_PATH;
+  	}
 
-	returnJourneyUrl(): any {
-		return this.RETURN_JOURNEY_URL;
-	}
+  	returnJourneyUrl(): any {
+  		return this.RETURN_JOURNEY_URL;
+  	}
 
-	sessionEventsTable(): any {
-		return this.SESSION_EVENTS_TABLE;
-	}
+  	sessionEventsTable(): any {
+  		return this.SESSION_EVENTS_TABLE;
+  	}
 
-	authEventsTable(): any {
-		return this.AUTH_EVENTS_TABLE;
-	}
+  	authEventsTable(): any {
+  		return this.AUTH_EVENTS_TABLE;
+  	}
 
-	authEventTtlSecs(): number {
-		return +this.AUTH_EVENT_TTL_SECS!;
-	}
+  	authEventTtlSecs(): number {
+  		return +this.AUTH_EVENT_TTL_SECS!;
+  	}
 
-	sessionReturnRecordTtlSecs(): number {
-		return +this.SESSION_RETURN_RECORD_TTL_SECS!;
-	}
+  	sessionReturnRecordTtlSecs(): number {
+  		return +this.SESSION_RETURN_RECORD_TTL_SECS!;
+  	}
 
-	getGovNotifyQueueURL(logger: Logger): string {
-		if (!this.GOV_NOTIFY_QUEUE_URL || this.GOV_NOTIFY_QUEUE_URL.trim().length === 0) {
-			logger.error({ message: "GovNotifyService - Misconfigured external API's key" }, { messageCode: MessageCodes.MISSING_CONFIGURATION });
-			throw new AppError(HttpCodesEnum.SERVER_ERROR, Constants.ENV_VAR_UNDEFINED);
-		}
-		return this.GOV_NOTIFY_QUEUE_URL;
-	}
+  	getGovNotifyQueueURL(logger: Logger): string {
+  		if (!this.GOV_NOTIFY_QUEUE_URL || this.GOV_NOTIFY_QUEUE_URL.trim().length === 0) {
+  			logger.error({ message: "GovNotifyService - Misconfigured external API's key" }, { messageCode: MessageCodes.MISSING_CONFIGURATION });
+  			throw new AppError(HttpCodesEnum.SERVER_ERROR, Constants.ENV_VAR_UNDEFINED);
+  		}
+  		return this.GOV_NOTIFY_QUEUE_URL;
+  	}
 
-	kmsKeyArn(): any {
-		return this.KMS_KEY_ARN;
-	}
+  	kmsKeyArn(): any {
+  		return this.KMS_KEY_ARN;
+  	}
 
-	oidcUrl(): any {
-		return this.OIDC_URL;
-	}
+  	oidcUrl(): any {
+  		return this.OIDC_URL;
+  	}
 
-	clientIdSsmPath(): any {
-		return this.CLIENT_ID_SSM_PATH;
-	}
+  	clientIdSsmPath(): any {
+  		return this.CLIENT_ID_SSM_PATH;
+  	}
 
-	returnRedirectUrl(): any {
-		return this.RETURN_REDIRECT_URL;
-	}
+  	returnRedirectUrl(): any {
+  		return this.RETURN_REDIRECT_URL;
+  	}
 
-	assumeRoleWithWebIdentityArn(): any {
-		return this.ASSUMEROLE_WITH_WEB_IDENTITY_ARN;
-	}
+  	assumeRoleWithWebIdentityArn(): any {
+  		return this.ASSUMEROLE_WITH_WEB_IDENTITY_ARN;
+  	}
 
-	oidcJwtAssertionTokenExpiry(): any {
-		return this.OIDC_JWT_ASSERTION_TOKEN_EXP;
-	}
+  	oidcJwtAssertionTokenExpiry(): any {
+  		return this.OIDC_JWT_ASSERTION_TOKEN_EXP;
+  	}
 
-	govukNotifyApiUrl(): any {
-		return this.GOVUKNOTIFY_API;
-	}
+  	govukNotifyApiUrl(): any {
+  		return this.GOVUKNOTIFY_API;
+  	}
 
-	getFallbackEmailTemplateId(): any {
-		return this.GOVUKNOTIFY_FALLBACK_EMAIL_TEMPLATE_ID;
-	}
+  	getFallbackEmailTemplateId(): any {
+  		return this.GOVUKNOTIFY_FALLBACK_EMAIL_TEMPLATE_ID;
+  	}
+
+  	issuer(): any {
+  		return this.ISSUER;
+  	}
 }

--- a/src/services/IPRServiceSession.ts
+++ b/src/services/IPRServiceSession.ts
@@ -144,7 +144,6 @@ export class IPRServiceSession {
 				event.restricted = event.restricted ?? { device_information: { encoded: "" } };
 				event.restricted.device_information = { encoded: encodedHeader };
 			}
-
 			const messageBody = JSON.stringify(event);
 			const params = {
 				MessageBody: messageBody,

--- a/src/services/SessionProcessor.ts
+++ b/src/services/SessionProcessor.ts
@@ -163,7 +163,7 @@ export class SessionProcessor {
 			try {
 				await iprService.sendToTXMA({
 					event_name: "IPR_USER_REDIRECTED",
-					...buildCoreEventFields({ user_id: sub, ip_address: clientIpAddress }),
+					...buildCoreEventFields({ user_id: sub, ip_address: clientIpAddress }, this.environmentVariables.issuer()),
 					extensions: {
 						previous_govuk_signin_journey_id: session.clientSessionId,
 				  },

--- a/src/tests/unit/SessionHandler.test.ts
+++ b/src/tests/unit/SessionHandler.test.ts
@@ -2,6 +2,7 @@ import { lambdaHandler } from "../../SessionHandler";
 import { VALID_SESSION, INVALID_SESSION } from "./data/session-events";
 import { SessionProcessor } from "../../services/SessionProcessor";
 import { mock } from "jest-mock-extended";
+import { EnvironmentVariables } from "../../services/EnvironmentVariables";
 
 const mockedSessionProcessor = mock<SessionProcessor>();
 jest.mock("../../utils/Config", () => {
@@ -9,6 +10,7 @@ jest.mock("../../utils/Config", () => {
 		getParameter: jest.fn(() => {return "client-id";}),
 	};
 });
+
 describe("SessionHandler", () => {
 	it("returns an not found response for an invalid resource request", async () => {
 		const response = await lambdaHandler(INVALID_SESSION, "IPR");
@@ -18,9 +20,12 @@ describe("SessionHandler", () => {
 
 	it("returns success response for a valid request payload", async () => {
 		SessionProcessor.getInstance = jest.fn().mockReturnValue(mockedSessionProcessor);
+		mockedSessionProcessor.processRequest.mockResolvedValue({ statusCode: 200, body: JSON.stringify({ message: "Success" }) });
 		const response = await lambdaHandler(VALID_SESSION, "IPR");
 
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		expect(mockedSessionProcessor.processRequest).toHaveBeenCalledTimes(1);
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.body)).toEqual({ message: "Success" });
 	});
 });

--- a/src/tests/unit/services/IPRServiceAuth.test.ts
+++ b/src/tests/unit/services/IPRServiceAuth.test.ts
@@ -37,6 +37,7 @@ function getTXMAEventPayload(): TxmaEvent {
 		},
 		timestamp: 123,
 		event_timestamp_ms: 123000,
+		component_id: "test-component-id",
 	};
 	return txmaEventPayload;
 }

--- a/src/tests/unit/services/IPRServiceSession.test.ts
+++ b/src/tests/unit/services/IPRServiceSession.test.ts
@@ -38,6 +38,7 @@ function getTXMAEventPayload(): TxmaEvent {
 		},
 		timestamp: 123,
 		event_timestamp_ms: 123000,
+		component_id: "test-component-id",
 	};
 	return txmaEventPayload;
 }

--- a/src/tests/unit/services/SendEmailProcessor.test.ts
+++ b/src/tests/unit/services/SendEmailProcessor.test.ts
@@ -25,6 +25,7 @@ let sqsEvent: SQSEvent;
 let sqsEventNewEmail: SQSEvent;
 let mockSessionEvent: SessionEvent;
 let mockExtSessionEvent: ExtSessionEvent;
+const MOCK_ISSUER = "test-mock-issuer";
 function getMockSessionEventItem(): SessionEvent {
 	const sess: SessionEvent = {
 		userId: "userId",
@@ -114,6 +115,8 @@ describe("SendEmailProcessor", () => {
 		sendEmailProcessorTest.govNotifyService = mockGovNotifyService;
 		// @ts-ignore
 		sendEmailProcessorTest.iprService = mockIprService;
+		// @ts-ignore
+		sendEmailProcessorTest.issuer = MOCK_ISSUER;
 		sqsEvent = VALID_GOV_NOTIFY_HANDLER_SQS_EVENT;
 		sqsEventNewEmail = VALID_GOV_NOTIFY_HANDLER_SQS_EVENT_DYNAMIC_EMAIL;
 		mockSessionEvent = getMockSessionEventItem();
@@ -151,6 +154,7 @@ describe("SendEmailProcessor", () => {
 			event_name: "IPR_RESULT_NOTIFICATION_EMAILED",
 			timestamp: 1585695600,
 			event_timestamp_ms: 1585695600000,
+			component_id: MOCK_ISSUER,
 			user: {
 				email: "test.user@digital.cabinet-office.gov.uk",
 				user_id: "user_id",
@@ -272,6 +276,7 @@ describe("SendEmailProcessor", () => {
 			event_name: "IPR_RESULT_NOTIFICATION_EMAILED",
 			timestamp: 1585695600,
 			event_timestamp_ms: 1585695600000,
+			component_id: MOCK_ISSUER,
 			user: {
 				email: "test.user@digital.cabinet-office.gov.uk",
 				user_id: "user_id",
@@ -312,6 +317,7 @@ describe("SendEmailProcessor", () => {
 			event_name: "IPR_RESULT_NOTIFICATION_EMAILED",
 			timestamp: 1585695600,
 			event_timestamp_ms: 1585695600000,
+			component_id: MOCK_ISSUER,
 			user: {
 				email: "test.user@digital.cabinet-office.gov.uk",
 				user_id: "user_id",

--- a/src/tests/unit/services/SessionProcessor.test.ts
+++ b/src/tests/unit/services/SessionProcessor.test.ts
@@ -25,6 +25,7 @@ import * as TxmaEventUtils from "../../../utils/TxmaEvent";
 let sessionProcessorTest: SessionProcessor;
 const mockIprService = mock<IPRServiceSession>();
 let mockSessionEvent: SessionEvent;
+const MOCK_ISSUER = "mock-issuer";
 const validPayload = {
 	iss: "issuer",
 	sub: "userId",
@@ -84,13 +85,20 @@ function getMockSessionEventItem(): SessionEvent {
 }
 
 describe("SessionProcessor", () => {
-	beforeAll(() => {
-		mockSessionEvent = getMockSessionEventItem();
-		sessionProcessorTest = new SessionProcessor(logger, metrics, CLIENT_ID);
-	});
-
 	beforeEach(() => {
 		jest.clearAllMocks();
+
+		process.env.KMS_KEY_ARN = "mock-kms-key-arn";
+		process.env.OIDC_URL = "https://mock-oidc-url.com";
+		process.env.OIDC_JWT_ASSERTION_TOKEN_EXP = "900";
+		process.env.ASSUMEROLE_WITH_WEB_IDENTITY_ARN = "mock-assume-role-arn";
+		process.env.SESSION_EVENTS_TABLE = "mock-session-events-table";
+		process.env.RETURN_REDIRECT_URL = "https://mock-redirect-url.com";
+		process.env.ISSUER = MOCK_ISSUER;
+
+		mockSessionEvent = getMockSessionEventItem();
+		sessionProcessorTest = new SessionProcessor(logger, metrics, CLIENT_ID);
+
 		// @ts-ignore
 		sessionProcessorTest.kmsJwtAdapter = passingKmsJwtAdapterFactory();
 		mockSessionEvent = getMockSessionEventItem();
@@ -272,6 +280,7 @@ describe("SessionProcessor", () => {
 				{
 					"event_name": "IPR_USER_REDIRECTED",
 					"event_timestamp_ms": 1585695600000,
+					"component_id": MOCK_ISSUER,
 					"extensions": { "previous_govuk_signin_journey_id": "sdfssg" },
 					"timestamp": 1585695600,
 					"user": { "ip_address": "1.1.1", "user_id": "userId" },
@@ -296,6 +305,7 @@ describe("SessionProcessor", () => {
 				{
 					"event_name": "IPR_USER_REDIRECTED",
 					"event_timestamp_ms": 1585695600000,
+					"component_id": MOCK_ISSUER,
 					"extensions": { "previous_govuk_signin_journey_id": "sdfssg" },
 					"timestamp": 1585695600,
 					"user": { "ip_address": "2.2.2", "user_id": "userId" },
@@ -318,6 +328,7 @@ describe("SessionProcessor", () => {
 				{
 					"event_name": "IPR_USER_REDIRECTED",
 					"event_timestamp_ms": 1585695600000,
+					"component_id": MOCK_ISSUER,
 					"extensions": { "previous_govuk_signin_journey_id": "sdfssg" },
 					"timestamp": 1585695600,
 					"user": { "ip_address": "", "user_id": "userId" },

--- a/src/tests/unit/utils/Txma.test.ts
+++ b/src/tests/unit/utils/Txma.test.ts
@@ -1,7 +1,9 @@
 import { buildCoreEventFields } from "../../../utils/TxmaEvent";
+import { EnvironmentVariables } from "../../../services/EnvironmentVariables";
 
 const user_id = "userId";
 const email = "test@test.com";
+const mockIssuer = "test-issuer";
 
 describe("TxmaEvents", () => {
 	beforeEach(() => {
@@ -16,18 +18,20 @@ describe("TxmaEvents", () => {
 
 	describe("buildCoreEventFields", () => {
 		it("Returns object with default values user and timestamp", () => {
-			expect(buildCoreEventFields({ user_id })).toEqual({
+			expect(buildCoreEventFields({ user_id }, mockIssuer)).toEqual({
 				user: { user_id },
 				timestamp: 1585695600,
 				event_timestamp_ms: 1585695600000,
+				component_id: mockIssuer,
 			});
 		});
 
 		it("Returns object with user with email if provided", () => {
-			expect(buildCoreEventFields({ user_id, email })).toEqual({
+			expect(buildCoreEventFields({ user_id, email }, mockIssuer)).toEqual({
 				user: { user_id, email },
 				timestamp: 1585695600,
 				event_timestamp_ms: 1585695600000,
+				component_id: mockIssuer,
 			});
 		});
 	});

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2020",
     "strict": true,
     "preserveConstEnums": true,
-    "sourceMap": false,
+    "sourceMap": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "esModuleInterop": true,

--- a/src/utils/TxmaEvent.ts
+++ b/src/utils/TxmaEvent.ts
@@ -14,6 +14,7 @@ export interface BaseTxmaEvent {
 	"user"?: TxmaUser;
 	"timestamp": number;
 	"event_timestamp_ms": number;
+	"component_id": string;
 }
 
 export interface ExtensionObject {
@@ -32,7 +33,7 @@ export interface RestrictedObject {
 	};
 }
 
-export const buildCoreEventFields = (user: TxmaUser ): BaseTxmaEvent => {
+export const buildCoreEventFields = (user: TxmaUser, issuer: string): BaseTxmaEvent => {
 	const now = Date.now();
 
 	return {
@@ -41,5 +42,6 @@ export const buildCoreEventFields = (user: TxmaUser ): BaseTxmaEvent => {
 		},
 		timestamp: Math.floor(now / 1000),
 		event_timestamp_ms: now,
+		component_id: issuer,
 	};
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

This change introduces the component_id field to all TxMA events. We've updated the EnvironmentVariables class to provide this ID, modified the TxmaEvent interface and buildCoreEventFields function to include it, and updated the SendEmailProcessor and SessionProcessor classes to use this new field. Corresponding test files have been updated to verify the presence of component_id in events. These changes improve event traceability and comply with new requirements for TxMA event structure.


## Proposed changes

### What changed

1. EnvironmentVariables.ts:
   - Added a new `componentId()` method to retrieve the COMPONENT_ID environment variable.

2. SendEmailProcessor.ts:
   - Updated the `processRequest` method to include `component_id` in TxMA events.
   - Modified the constructor to accept and store an EnvironmentVariables instance.

3. SessionProcessor.ts:
   - Updated the `processRequest` method to include `component_id` in TxMA events.
   - Modified the constructor to accept and store an EnvironmentVariables instance.

4. SendEmailProcessor.test.ts:
   - Updated tests to mock EnvironmentVariables and expect `component_id` in TxMA events.
   - Added new test cases to specifically check for the presence of `component_id`.

5. SessionProcessor.test.ts:
   - Updated tests to mock EnvironmentVariables and expect `component_id` in TxMA events.
   - Added new test cases to specifically check for the presence of `component_id`.

6. Txma.test.ts:
   - Updated `buildCoreEventFields` tests to include `component_id` expectations.
   - Added new test cases for `component_id` handling.

7. TxmaEvent.ts:
   - Modified the `TxmaEvent` interface to include `component_id` as a required field.
   - Updated the `buildCoreEventFields` function to accept EnvironmentVariables and include `component_id` in the returned object.

### Why did it change

- To comply with new requirements to include `component_id` in all TxMA events for better traceability and context.
- To ensure consistent handling of `component_id` across different parts of the application.
- To improve type safety by making `component_id` a required field in the TxmaEvent interface.
- To centralise the retrieval of `component_id` through the EnvironmentVariables class, promoting better code organisation and easier future modifications.


<img width="600" alt="image" src="https://github.com/user-attachments/assets/6889d100-c63a-419c-a8f5-345c3d6dc4a8">

![Screenshot 2024-09-19 at 12 39 17](https://github.com/user-attachments/assets/afda5ef2-836d-448a-b064-ea58ab7851ae)


### Issue tracking


## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
