### PR TITLE
Updating GitHub provided action to new version

### DIFF
--- a/.github/workflows/pull-request-sonar.yml
+++ b/.github/workflows/pull-request-sonar.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Test and coverage
         run: npm run test:unit -- --coverage
       - name: Run SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@0739d7e7a19bae3177cf851ae51944bb4dd53565 #30th Jan 2024
         with:
           coverage-location: src/coverage/
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Archive coverage results
         if: ${{ inputs.coverage-report }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
          name: ${{ inputs.coverage-artifact }}
          retention-days: 3


### PR DESCRIPTION
EOL on the 5th December 2024

Also updated version of Sonar Cloud as it needs to use download-artifact v4 as well

https://govukverify.atlassian.net/browse/PSREDEV-1911

## Proposed changes
https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new

### What changed

Updated a GH action

### Why did it change

V3 being EOLed 5th Dec

### Issue tracking
https://govukverify.atlassian.net/browse/PSREDEV-1911
