### PR TITLE
[KIWI-1967]- IPR | BE | Delete User Session Based on IPV_F2F_USER_CANCEL_END events

### DIFF
--- a/deploy/samconfig.toml
+++ b/deploy/samconfig.toml
@@ -2,8 +2,8 @@ version = 0.1
 [dev]
 [dev.deploy]
 [dev.deploy.parameters]
-stack_name = "ipvreturn-api"
-s3_prefix = "ipvreturn-api"
+stack_name = "ipvreturn-api-1967c"
+s3_prefix = "ipvreturn-api-1967c"
 region = "eu-west-2"
 confirm_changeset = false
 capabilities = "CAPABILITY_IAM"

--- a/deploy/samconfig.toml
+++ b/deploy/samconfig.toml
@@ -2,8 +2,8 @@ version = 0.1
 [dev]
 [dev.deploy]
 [dev.deploy.parameters]
-stack_name = "ipvreturn-api-1967c"
-s3_prefix = "ipvreturn-api-1967c"
+stack_name = "ipvreturn-api"
+s3_prefix = "ipvreturn-api"
 region = "eu-west-2"
 confirm_changeset = false
 capabilities = "CAPABILITY_IAM"

--- a/src/models/ReturnSQSEvent.ts
+++ b/src/models/ReturnSQSEvent.ts
@@ -6,6 +6,8 @@ export type EventType = "AUTH_IPV_AUTHORISATION_REQUESTED" | "F2F_YOTI_START" | 
 export interface ReturnSQSEvent {
 	event_id: string;
 	client_id: string;
+	component_id?: string;
+	redirect_uri?: string;
 	clientLandingPageUrl?: string;
 	event_name: EventType;
 	timestamp: number;

--- a/src/models/ReturnSQSEvent.ts
+++ b/src/models/ReturnSQSEvent.ts
@@ -1,6 +1,6 @@
 import { NamePart, PostOfficeVisitDetails, PostOfficeInfo, DocumentDetails } from "./SessionReturnRecord";
 
-export type EventType = "AUTH_IPV_AUTHORISATION_REQUESTED" | "F2F_YOTI_START" | "IPV_F2F_CRI_VC_CONSUMED" | "AUTH_DELETE_ACCOUNT" | "F2F_DOCUMENT_UPLOADED";
+export type EventType = "AUTH_IPV_AUTHORISATION_REQUESTED" | "F2F_YOTI_START" | "IPV_F2F_CRI_VC_CONSUMED" | "AUTH_DELETE_ACCOUNT" | "F2F_DOCUMENT_UPLOADED" | "IPV_F2F_USER_CANCEL_END";
 
 
 export interface ReturnSQSEvent {

--- a/src/models/SessionEvent.ts
+++ b/src/models/SessionEvent.ts
@@ -102,8 +102,6 @@ export class ExtSessionEvent extends SessionEvent {
 	@IsNotEmpty()
 	documentUploadedOn!: number;
 
-	@IsNumber()
-	@IsNotEmpty()
 	accountDeletedOn?: number;
 
 	@IsString()

--- a/src/models/SessionEvent.ts
+++ b/src/models/SessionEvent.ts
@@ -102,6 +102,10 @@ export class ExtSessionEvent extends SessionEvent {
 	@IsNotEmpty()
 	documentUploadedOn!: number;
 
+	@IsNumber()
+	@IsNotEmpty()
+	accountDeletedOn?: number;
+
 	@IsString()
 	@IsNotEmpty()
 	documentType!: string;
@@ -109,6 +113,7 @@ export class ExtSessionEvent extends SessionEvent {
 	@IsString()
 	@IsNotEmpty()
 	documentExpiryDate!: string;
+	
 
 	@IsArray()
 	@IsNotEmpty()

--- a/src/models/SessionReturnRecord.ts
+++ b/src/models/SessionReturnRecord.ts
@@ -75,7 +75,8 @@ export class SessionReturnRecord {
 				this.postOfficeVisitDetails = data.extensions?.post_office_visit_details;
 				break;
 			}
-			case Constants.AUTH_DELETE_ACCOUNT || Constants.IPV_F2F_USER_CANCEL_END: {
+			case Constants.AUTH_DELETE_ACCOUNT:
+			case Constants.IPV_F2F_USER_CANCEL_END: {
 				this.accountDeletedOn = data.timestamp;
 				this.clientSessionId = "";
 				this.clientName = "";

--- a/src/models/SessionReturnRecord.ts
+++ b/src/models/SessionReturnRecord.ts
@@ -75,16 +75,7 @@ export class SessionReturnRecord {
 				this.postOfficeVisitDetails = data.extensions?.post_office_visit_details;
 				break;
 			}
-			case Constants.AUTH_DELETE_ACCOUNT: {
-				this.accountDeletedOn = data.timestamp;
-				this.clientSessionId = "";
-				this.clientName = "";
-				this.redirectUri = "";
-				this.userEmail = "";
-				this.nameParts = [];
-				break;
-			}
-			case Constants.IPV_F2F_USER_CANCEL_END: {
+			case Constants.AUTH_DELETE_ACCOUNT || Constants.IPV_F2F_USER_CANCEL_END: {
 				this.accountDeletedOn = data.timestamp;
 				this.clientSessionId = "";
 				this.clientName = "";

--- a/src/models/SessionReturnRecord.ts
+++ b/src/models/SessionReturnRecord.ts
@@ -84,6 +84,15 @@ export class SessionReturnRecord {
 				this.nameParts = [];
 				break;
 			}
+			case Constants.IPV_F2F_USER_CANCEL_END: {
+				this.accountDeletedOn = data.timestamp;
+				this.clientSessionId = "";
+				this.clientName = "";
+				this.redirectUri = "";
+				this.userEmail = "";
+				this.nameParts = [];
+				break;
+			}
 			default: {
 				break;
 			}

--- a/src/services/IPRServiceSession.ts
+++ b/src/services/IPRServiceSession.ts
@@ -87,7 +87,7 @@ export class IPRServiceSession {
 				this.logger.info({ message: "Received AUTH_DELETE_ACCOUNT event and no session with that userId was found OR session was found but accountDeletedOn was already set" });
 				return true;
 			// If Event type is IPV_F2F_USER_CANCEL_END and no record was found, or flagged for deletion then do not process the event.
-			} else if (eventType === Constants.IPV_F2F_USER_CANCEL_END && (!session.Item || (session?.Item && session?.Item?.accountDeletedOn))) {
+			} else if (eventType === Constants.IPV_F2F_USER_CANCEL_END && (!session.Item || session?.Item?.accountDeletedOn)) {
 				this.logger.info({ message: "Received IPV_F2F_USER_CANCEL_END event and no session with that userId was found OR session was found but accountDeletedOn was already set" });
 				return true;
 			} else if (session.Item && (session.Item.accountDeletedOn || session.Item[eventAttribute!])) {

--- a/src/services/IPRServiceSession.ts
+++ b/src/services/IPRServiceSession.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { Logger } from "@aws-lambda-powertools/logger";
 import { AppError } from "../utils/AppError";
-import { DynamoDBDocument, GetCommand, UpdateCommand, DeleteCommand } from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocument, GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { HttpCodesEnum } from "../models/enums/HttpCodesEnum";
 import { Constants } from "../utils/Constants";
 import { sqsClient } from "../utils/SqsClient";
@@ -119,24 +119,6 @@ export class IPRServiceSession {
 		} catch (e: any) {
 			this.logger.error({ message: "Failed to update session record in dynamo", e });
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error updating session record");
-		}
-	}
-
-	async deleteUserRecord(userId: string): Promise<any> {
-		const deleteUserRecordCommand = new DeleteCommand({
-			TableName: this.tableName,
-			Key: {
-				userId,
-			},
-		});
-
-		this.logger.info({ message: "Deleting session record" });
-
-		try {
-			await this.dynamo.send(deleteUserRecordCommand);
-		} catch (e: any) {
-			this.logger.error({ message: "Failed to delete session record", e });
-			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error deleting session record");
 		}
 	}
 

--- a/src/services/IPRServiceSession.ts
+++ b/src/services/IPRServiceSession.ts
@@ -86,12 +86,16 @@ export class IPRServiceSession {
 			if (eventType === Constants.AUTH_DELETE_ACCOUNT && (!session.Item || (session.Item && session.Item.accountDeletedOn))) {
 				this.logger.info({ message: "Received AUTH_DELETE_ACCOUNT event and no session with that userId was found OR session was found but accountDeletedOn was already set" });
 				return true;
+			// If Event type is IPV_F2F_USER_CANCEL_END and no record was found, or flagged for deletion then do not process the event.
+			} else if (eventType === Constants.IPV_F2F_USER_CANCEL_END && (!session.Item || (session.Item && session.Item.accountDeletedOn))) {
+				this.logger.info({ message: "Received IPV_F2F_USER_CANCEL_END event and no session with that userId was found OR session was found but accountDeletedOn was already set" });
+				return true;
 			} else if (session.Item && (session.Item.accountDeletedOn || session.Item[eventAttribute!])) {
 				// Do not process the event if the record is flagged for deletion or the event mapped attribute exists.
 				this.logger.info({ message: `Session record with that userId was found with either accountDeletedOn set or with ${eventAttribute} already set` });
 				return true;
 			} else {
-				// Process all events except AUTH_DELETE_ACCOUNT when no record exists.
+				// Process all events except AUTH_DELETE_ACCOUNT or IPV_F2F_USER_CANCEL_END when no record exists.
 				return false;
 			}
 		} catch (e: any) {

--- a/src/services/IPRServiceSession.ts
+++ b/src/services/IPRServiceSession.ts
@@ -87,7 +87,7 @@ export class IPRServiceSession {
 				this.logger.info({ message: "Received AUTH_DELETE_ACCOUNT event and no session with that userId was found OR session was found but accountDeletedOn was already set" });
 				return true;
 			// If Event type is IPV_F2F_USER_CANCEL_END and no record was found, or flagged for deletion then do not process the event.
-			} else if (eventType === Constants.IPV_F2F_USER_CANCEL_END && (!session.Item || (session.Item && session.Item.accountDeletedOn))) {
+			} else if (eventType === Constants.IPV_F2F_USER_CANCEL_END && (!session.Item || (session?.Item && session?.Item?.accountDeletedOn))) {
 				this.logger.info({ message: "Received IPV_F2F_USER_CANCEL_END event and no session with that userId was found OR session was found but accountDeletedOn was already set" });
 				return true;
 			} else if (session.Item && (session.Item.accountDeletedOn || session.Item[eventAttribute!])) {

--- a/src/services/IPRServiceSession.ts
+++ b/src/services/IPRServiceSession.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { Logger } from "@aws-lambda-powertools/logger";
 import { AppError } from "../utils/AppError";
-import { DynamoDBDocument, GetCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocument, GetCommand, UpdateCommand, DeleteCommand } from "@aws-sdk/lib-dynamodb";
 import { HttpCodesEnum } from "../models/enums/HttpCodesEnum";
 import { Constants } from "../utils/Constants";
 import { sqsClient } from "../utils/SqsClient";
@@ -119,6 +119,24 @@ export class IPRServiceSession {
 		} catch (e: any) {
 			this.logger.error({ message: "Failed to update session record in dynamo", e });
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error updating session record");
+		}
+	}
+
+	async deleteUserRecord(userId: string): Promise<any> {
+		const deleteUserRecordCommand = new DeleteCommand({
+			TableName: this.tableName,
+			Key: {
+				userId,
+			},
+		});
+
+		this.logger.info({ message: "Deleting session record" });
+
+		try {
+			await this.dynamo.send(deleteUserRecordCommand);
+		} catch (e: any) {
+			this.logger.error({ message: "Failed to delete session record", e });
+			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error deleting session record");
 		}
 	}
 

--- a/src/services/IPRServiceSession.ts
+++ b/src/services/IPRServiceSession.ts
@@ -84,7 +84,7 @@ export class IPRServiceSession {
 			const session = await this.dynamo.send(getSessionCommand);
 			const eventAttribute = this.eventAttributeMap.get(eventType);
 			// If Event type is AUTH_DELETE_ACCOUNT or IPV_F2F_USER_CANCEL_END and no record was found, or flagged for deletion then do not process the event.
-			if ((eventType === Constants.AUTH_DELETE_ACCOUNT || eventType === Constants.IPV_F2F_USER_CANCEL_END) && (!session.Item || (session.Item && session.Item.accountDeletedOn))) {
+			if ((eventType === Constants.AUTH_DELETE_ACCOUNT || eventType === Constants.IPV_F2F_USER_CANCEL_END) && (!session.Item || session?.Item?.accountDeletedOn)) {
 				this.logger.info({ message: `Received ${eventType} event and no session with that userId was found OR session was found but accountDeletedOn was already set` });
 				return true;
 			} else if (session.Item && (session.Item.accountDeletedOn || session.Item[eventAttribute!])) {

--- a/src/services/IPRServiceSession.ts
+++ b/src/services/IPRServiceSession.ts
@@ -84,7 +84,7 @@ export class IPRServiceSession {
 			const session = await this.dynamo.send(getSessionCommand);
 			const eventAttribute = this.eventAttributeMap.get(eventType);
 			// If Event type is AUTH_DELETE_ACCOUNT or IPV_F2F_USER_CANCEL_END and no record was found, or flagged for deletion then do not process the event.
-			if ((eventType === Constants.AUTH_DELETE_ACCOUNT || Constants.IPV_F2F_USER_CANCEL_END) && (!session.Item || (session.Item && session.Item.accountDeletedOn))) {
+			if ((eventType === Constants.AUTH_DELETE_ACCOUNT || eventType === Constants.IPV_F2F_USER_CANCEL_END) && (!session.Item || (session.Item && session.Item.accountDeletedOn))) {
 				this.logger.info({ message: `Received ${eventType} event and no session with that userId was found OR session was found but accountDeletedOn was already set` });
 				return true;
 			} else if (session.Item && (session.Item.accountDeletedOn || session.Item[eventAttribute!])) {

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -191,13 +191,18 @@ export class PostEventProcessor {
 					};
 					break;
 				}
+				case Constants.IPV_F2F_USER_CANCEL_END: {
+					expressionAttributeValues = {}
+					await this.iprServiceSession.deleteUserRecord(userId);
+					break;
+				}
 				default:
 					this.logger.error({ message: "Unexpected event received in SQS queue:", eventName });
 					throw new AppError(HttpCodesEnum.SERVER_ERROR, "Unexpected event received");
 			}
 
 			if (!updateExpression || !expressionAttributeValues) {
-				this.logger.error({ message: "Missing config to update DynamboDB for event:", eventName });
+				this.logger.error({ message: "Missing config to update DynamoDB for event:", eventName });
 				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Missing event config");
 			}
 

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -198,7 +198,7 @@ export class PostEventProcessor {
 			}
 
 			if (!updateExpression || !expressionAttributeValues) {
-				this.logger.error({ message: "Missing config to update DynamoDB for event:", eventName });
+				this.logger.error({ message: "Missing config to update DynamboDB for event:", eventName });
 				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Missing event config");
 			}
 

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -180,7 +180,8 @@ export class PostEventProcessor {
 					};
 					break;
 				}
-				case Constants.AUTH_DELETE_ACCOUNT || Constants.IPV_F2F_USER_CANCEL_END: {
+				case Constants.AUTH_DELETE_ACCOUNT:
+				case Constants.IPV_F2F_USER_CANCEL_END: {
 					updateExpression = "SET accountDeletedOn = :accountDeletedOn, userEmail = :userEmail, nameParts = :nameParts, clientName = :clientName,  redirectUri = :redirectUri";
 					expressionAttributeValues = {
 						":accountDeletedOn": returnRecord.accountDeletedOn,

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -180,18 +180,7 @@ export class PostEventProcessor {
 					};
 					break;
 				}
-				case Constants.AUTH_DELETE_ACCOUNT: {
-					updateExpression = "SET accountDeletedOn = :accountDeletedOn, userEmail = :userEmail, nameParts = :nameParts, clientName = :clientName,  redirectUri = :redirectUri";
-					expressionAttributeValues = {
-						":accountDeletedOn": returnRecord.accountDeletedOn,
-						":userEmail": returnRecord.userEmail,
-						":nameParts":returnRecord.nameParts,
-						":clientName": returnRecord.clientName,
-						":redirectUri": returnRecord.redirectUri,
-					};
-					break;
-				}
-				case Constants.IPV_F2F_USER_CANCEL_END: {
+				case Constants.AUTH_DELETE_ACCOUNT || Constants.IPV_F2F_USER_CANCEL_END: {
 					updateExpression = "SET accountDeletedOn = :accountDeletedOn, userEmail = :userEmail, nameParts = :nameParts, clientName = :clientName,  redirectUri = :redirectUri";
 					expressionAttributeValues = {
 						":accountDeletedOn": returnRecord.accountDeletedOn,

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -192,8 +192,14 @@ export class PostEventProcessor {
 					break;
 				}
 				case Constants.IPV_F2F_USER_CANCEL_END: {
-					expressionAttributeValues = {}
-					await this.iprServiceSession.deleteUserRecord(userId);
+					updateExpression = "SET accountDeletedOn = :accountDeletedOn, userEmail = :userEmail, nameParts = :nameParts, clientName = :clientName,  redirectUri = :redirectUri";
+					expressionAttributeValues = {
+						":accountDeletedOn": returnRecord.accountDeletedOn,
+						":userEmail": returnRecord.userEmail,
+						":nameParts":returnRecord.nameParts,
+						":clientName": returnRecord.clientName,
+						":redirectUri": returnRecord.redirectUri,
+					};
 					break;
 				}
 				default:

--- a/src/tests/api/postEventStream.test.ts
+++ b/src/tests/api/postEventStream.test.ts
@@ -4,11 +4,13 @@ import {
 	VALID_IPV_F2F_CRI_VC_CONSUMED_WITH_DOC_EXPIRYDATE_TXMA_EVENT,
 	VALID_F2F_YOTI_START_WITH_PO_DOC_DETAILS_TXMA_EVENT,
 	VALID_F2F_DOCUMENT_UPLOADED_TXMA_EVENT,
+	VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT,
 } from "../data/sqs-events";
 import "dotenv/config";
 import { randomUUID } from "crypto";
 import { constants } from "./utils/ApiConstants";
 import { postMockEvent, getSessionByUserId } from "./utils/ApiTestSteps";
+import { sleep } from "../../utils/Sleep";
 
 describe("post event processor", () => {
 	jest.setTimeout(60000);
@@ -104,6 +106,67 @@ describe("post event processor", () => {
 		expect(response?.clientName).toBe("ekwU");
 		expect(response?.redirectUri).toBe("REDIRECT_URL");
 		expect(response?.userEmail).toBe(constants.API_TEST_EMAIL_ADDRESS);
+		expect(response?.documentType).toBe("PASSPORT");
+		expect(response?.documentExpiryDate).toBe("2030-01-01");
+		expect(response?.postOfficeInfo).toEqual([
+			{
+				"M": {
+					"address": {
+						"S": "1 The Street, Funkytown",
+					},
+					"location": {
+						"L": [
+							{
+								"M": {
+									"latitude": {
+										"N": "0.34322",
+									},
+									"longitude": {
+										"N": "-42.48372",
+									},
+								},
+							},
+						],
+					},
+					"name": {
+						"S": "Post Office Name",
+					},
+					"post_code": {
+						"S": "N1 2AA",
+					},
+				},
+			},
+		]);
+		expect(response?.postOfficeVisitDetails).toEqual([
+			{
+				"M": {
+					"post_office_date_of_visit": {
+						"S": "7 September 2023",
+					},
+					"post_office_time_of_visit": {
+						"S": "4:43 pm",
+					},
+				},
+			},
+		]);
+	}, 20000); // timeout set to 20s to avoid infinite loop
+
+	it("PII is removed and record is marked for deletion when IPV_F2F_USER_CANCEL_END event is sent", async () => {
+		await postMockEvent(VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT, userId, true);
+		await postMockEvent(VALID_F2F_YOTI_START_WITH_PO_DOC_DETAILS_TXMA_EVENT, userId, false);
+		await postMockEvent(VALID_F2F_DOCUMENT_UPLOADED_TXMA_EVENT, userId, false);
+		await postMockEvent(VALID_IPV_F2F_CRI_VC_CONSUMED_WITH_DOC_EXPIRYDATE_TXMA_EVENT, userId, false);
+		await postMockEvent(VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT, userId, false);
+		await sleep(2000);
+
+		const response = await getSessionByUserId(userId, constants.API_TEST_SESSION_EVENTS_TABLE!);
+
+		expect(response?.notified).toBe(true);
+		expect(response?.nameParts).toEqual([]);
+		expect(response?.clientName).toBe("");
+		expect(response?.accountDeletedOn).toBeTruthy();
+		expect(response?.redirectUri).toBe("");
+		expect(response?.userEmail).toBe("");
 		expect(response?.documentType).toBe("PASSPORT");
 		expect(response?.documentExpiryDate).toBe("2030-01-01");
 		expect(response?.postOfficeInfo).toEqual([

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -186,6 +186,23 @@ export const VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT = {
 
 export const VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT_STRING = JSON.stringify(VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT);
 
+export const VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT = {
+	event_id: "588f4a66-f75a-4728-9f7b-8afd865c233f",
+	client_id: "ekwU",
+	component_id: "UNKNOWN",
+	event_name: "IPV_F2F_USER_CANCEL_END",
+	redirect_uri: "www.localhost.com",
+	timestamp: 1681902001,
+	timestamp_formatted: "2023-04-19T11:00:01.000Z",
+	user: {
+		user_id: "01333e01-dde3-412f-a484-3333",
+		// pragma: allowlist nextline secret
+		email: "e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454",
+	},
+};
+
+export const VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT_STRING = JSON.stringify(VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT);
+
 
 export const VALID_GOV_NOTIFY_SQS_TXMA_EVENT = {
 	Message: {

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -196,7 +196,7 @@ export const VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT: ReturnSQSEvent = {
 	"timestamp": 1681902001,
 	"event_timestamp_ms": 1681902001713,
 	"timestamp_formatted": "2023-04-19T11:00:01.000Z",
-  };
+};
 
 export const VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT_STRING = JSON.stringify(VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT);
 

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -51,6 +51,7 @@ export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT: ReturnSQSEvent =
 	client_id: "ekwU",
 	clientLandingPageUrl: "REDIRECT_URL",
 	event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
+	// rp_name: "replay",
 	timestamp: 1681902001,
 	event_timestamp_ms: 1681902001713,
 	timestamp_formatted: "2023-04-19T11:00:01.000Z",

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -51,7 +51,6 @@ export const VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT: ReturnSQSEvent =
 	client_id: "ekwU",
 	clientLandingPageUrl: "REDIRECT_URL",
 	event_name: "AUTH_IPV_AUTHORISATION_REQUESTED",
-	// rp_name: "replay",
 	timestamp: 1681902001,
 	event_timestamp_ms: 1681902001713,
 	timestamp_formatted: "2023-04-19T11:00:01.000Z",

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -186,20 +186,17 @@ export const VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT = {
 
 export const VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT_STRING = JSON.stringify(VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT);
 
-export const VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT = {
-	event_id: "588f4a66-f75a-4728-9f7b-8afd865c233f",
-	client_id: "ekwU",
-	component_id: "UNKNOWN",
-	event_name: "IPV_F2F_USER_CANCEL_END",
-	redirect_uri: "www.localhost.com",
-	timestamp: 1681902001,
-	timestamp_formatted: "2023-04-19T11:00:01.000Z",
-	user: {
-		user_id: "01333e01-dde3-412f-a484-3333",
-		// pragma: allowlist nextline secret
-		email: "e914e32172adcdad6c0906f7e5a0f4f43a6e99847c4370df783c7142f71ba454",
+export const VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT: ReturnSQSEvent = {
+	"event_name": "IPV_F2F_USER_CANCEL_END",
+	"event_id": "588f4a66-f75a-4728-9f7b-8afd865c233f",
+	"client_id": "ekwU",
+	"user": {
+	  "user_id": "7561b2c4-7466-4d58-ad02-d52c1b900bf9",
 	},
-};
+	"timestamp": 1681902001,
+	"event_timestamp_ms": 1681902001713,
+	"timestamp_formatted": "2023-04-19T11:00:01.000Z",
+  };
 
 export const VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT_STRING = JSON.stringify(VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT);
 

--- a/src/tests/unit/services/IPRServiceSession.test.ts
+++ b/src/tests/unit/services/IPRServiceSession.test.ts
@@ -171,6 +171,24 @@ describe("IPR Service", () => {
 			const result = await iprServiceSession.isFlaggedForDeletionOrEventAlreadyProcessed(userId, Constants.AUTH_DELETE_ACCOUNT);
 			expect(result).toBe(true);
 		});
+
+		it("Should not process the IPV_F2F_USER_CANCEL_END event if value is set for accountDeletedOn", async () => {
+			const recordFlaggedForAlreadyProcessed = {
+				Item: {
+					accountDeletedOn: 1681902001,
+					userId: "SESSID",
+				},
+			};
+			mockDynamoDbClient.send = jest.fn().mockResolvedValue(recordFlaggedForAlreadyProcessed);
+			const result = await iprServiceSession.isFlaggedForDeletionOrEventAlreadyProcessed(userId, Constants.IPV_F2F_USER_CANCEL_END);
+			expect(result).toBe(true);
+		});
+	
+		it("Should not process the IPV_F2F_USER_CANCEL_END session record is not found", async () => {
+			mockDynamoDbClient.send = jest.fn().mockResolvedValue({});
+			const result = await iprServiceSession.isFlaggedForDeletionOrEventAlreadyProcessed(userId, Constants.IPV_F2F_USER_CANCEL_END);
+			expect(result).toBe(true);
+		});
 	});
 
 	describe("saveEventData", () => {

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -448,4 +448,10 @@ describe("PostEventProcessor", () => {
 			expect(mockLogger.error).toHaveBeenNthCalledWith(1, { "message": "F2F_YOTI_START event received before AUTH_IPV_AUTHORISATION_REQUESTED event" }, { "messageCode": "SQS_OUT_OF_SYNC" });	
 		});
 	});
+
+	describe("IPV_F2F_USER_CANCEL_END event", () => {
+		it("deletes the user Dynano DB record in the session table", async () => {
+			
+		})
+	})
 });

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -13,9 +13,9 @@ import { AppError } from "../../../utils/AppError";
 import { Constants } from "../../../utils/Constants";
 import {
 	VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT_STRING,
+	VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT_STRING,
 	VALID_AUTH_IPV_AUTHORISATION_REQUESTED_TXMA_EVENT_STRING,
 	VALID_F2F_DOCUMENT_UPLOADED_TXMA_EVENT,
-	VALID_F2F_YOTI_START_TXMA_EVENT,
 	VALID_F2F_YOTI_START_TXMA_EVENT_STRING, VALID_F2F_YOTI_START_WITH_PO_DOC_DETAILS_TXMA_EVENT,
 	VALID_IPV_F2F_CRI_VC_CONSUMED_TXMA_EVENT_STRING,
 	VALID_IPV_F2F_CRI_VC_CONSUMED_WITH_DOC_EXPIRYDATE_TXMA_EVENT_STRING,
@@ -265,6 +265,12 @@ describe("PostEventProcessor", () => {
 	
 		it("Calls saveEventData with appropriate payload for AUTH_DELETE_ACCOUNT_EVENT event", async () => {
 			await postEventProcessorMockSessionService.processRequest(VALID_AUTH_DELETE_ACCOUNT_TXMA_EVENT_STRING);
+			// eslint-disable-next-line @typescript-eslint/unbound-method
+			expect(mockIprServiceSession.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-3333", "SET accountDeletedOn = :accountDeletedOn, userEmail = :userEmail, nameParts = :nameParts, clientName = :clientName,  redirectUri = :redirectUri", { ":accountDeletedOn": 1681902001, ":clientName": "", ":nameParts": [], ":redirectUri": "", ":userEmail": "" });
+		});
+
+		it("Calls saveEventData with appropriate payload for IPV_F2F_USER_CANCEL_END event", async () => {
+			await postEventProcessorMockSessionService.processRequest(VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT_STRING);
 			// eslint-disable-next-line @typescript-eslint/unbound-method
 			expect(mockIprServiceSession.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-3333", "SET accountDeletedOn = :accountDeletedOn, userEmail = :userEmail, nameParts = :nameParts, clientName = :clientName,  redirectUri = :redirectUri", { ":accountDeletedOn": 1681902001, ":clientName": "", ":nameParts": [], ":redirectUri": "", ":userEmail": "" });
 		});

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -272,7 +272,7 @@ describe("PostEventProcessor", () => {
 		it("Calls saveEventData with appropriate payload for IPV_F2F_USER_CANCEL_END event", async () => {
 			await postEventProcessorMockSessionService.processRequest(VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT_STRING);
 			// eslint-disable-next-line @typescript-eslint/unbound-method
-			expect(mockIprServiceSession.saveEventData).toHaveBeenCalledWith("01333e01-dde3-412f-a484-3333", "SET accountDeletedOn = :accountDeletedOn, userEmail = :userEmail, nameParts = :nameParts, clientName = :clientName,  redirectUri = :redirectUri", { ":accountDeletedOn": 1681902001, ":clientName": "", ":nameParts": [], ":redirectUri": "", ":userEmail": "" });
+			expect(mockIprServiceSession.saveEventData).toHaveBeenCalledWith("7561b2c4-7466-4d58-ad02-d52c1b900bf9", "SET accountDeletedOn = :accountDeletedOn, userEmail = :userEmail, nameParts = :nameParts, clientName = :clientName,  redirectUri = :redirectUri", { ":accountDeletedOn": 1681902001, ":clientName": "", ":nameParts": [], ":redirectUri": "", ":userEmail": "" });
 		});
 	});
 

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -458,6 +458,6 @@ describe("PostEventProcessor", () => {
 	describe("IPV_F2F_USER_CANCEL_END event", () => {
 		it("deletes the user Dynano DB record in the session table", async () => {
 			
-		})
-	})
+		});
+	});
 });

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -454,10 +454,4 @@ describe("PostEventProcessor", () => {
 			expect(mockLogger.error).toHaveBeenNthCalledWith(1, { "message": "F2F_YOTI_START event received before AUTH_IPV_AUTHORISATION_REQUESTED event" }, { "messageCode": "SQS_OUT_OF_SYNC" });	
 		});
 	});
-
-	describe("IPV_F2F_USER_CANCEL_END event", () => {
-		it("deletes the user Dynano DB record in the session table", async () => {
-			
-		});
-	});
 });

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -22,6 +22,8 @@ export class Constants {
 
     static readonly AUTH_DELETE_ACCOUNT = "AUTH_DELETE_ACCOUNT";
 
+    static readonly IPV_F2F_USER_CANCEL_END = "IPV_F2F_USER_CANCEL_END";
+
     static readonly POSTEVENT_LOGGER_SVC_NAME = "PostEventHandler";
 
     static readonly STREAM_PROCESSOR_LOGGER_SVC_NAME = "StreamProcessorHandler";


### PR DESCRIPTION
### What changed

Functionality added to "delete" a user's record in the session table if they choose to reset their VC from IPV core. This is the same as the existing code that runs after AUTH_DELETE_ACCOUNT event is consumed, but IPV_F2F_USER_CANCEL_END will come from a different place

### Why did it change

To allow users to reset their pending VCs without fully deleting their account

### Issue tracking

- [KIWI-1967](https://govukverify.atlassian.net/browse/KIWI-1967)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-1967]: https://govukverify.atlassian.net/browse/KIWI-1967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1512" alt="Screenshot 2024-12-05 at 15 54 02" src="https://github.com/user-attachments/assets/3030ca4b-ba3a-40ab-b253-23977009ba54">

<img width="1512" alt="Screenshot 2024-12-05 at 15 54 15" src="https://github.com/user-attachments/assets/e98f16cd-e76d-4759-8d03-753f644b9f1b">

<img width="1512" alt="Screenshot 2024-12-05 at 15 54 27" src="https://github.com/user-attachments/assets/fb645a2b-6ed3-4117-ad81-4dceefe63203">
