### PR TITLE
[KIWI-2055] - IPR | BE | Error Handling for cancelling F2F VCs

### DIFF
--- a/src/PostEventHandler.ts
+++ b/src/PostEventHandler.ts
@@ -48,7 +48,7 @@ class PostEventHandler implements LambdaInterface {
 
 			} catch (error: any) {
 				logger.error({ message: "SQS Event could not be processed", error });
-				if(body.event_name === Constants.IPV_F2F_USER_CANCEL_END && error.message === "Error updating session record") {
+				if (body.event_name === Constants.IPV_F2F_USER_CANCEL_END && error.message === "Error updating session record") {
 					throw new AppError(HttpCodesEnum.BAD_REQUEST, "SQS Event could not be processed");
 				} else {
 					return { batchItemFailures:[] };

--- a/src/PostEventHandler.ts
+++ b/src/PostEventHandler.ts
@@ -1,8 +1,11 @@
 import { SQSBatchResponse, SQSEvent, SQSRecord } from "aws-lambda";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { Metrics } from "@aws-lambda-powertools/metrics";
+import { AppError } from "./utils/AppError";
+import { HttpCodesEnum } from "./models/enums/HttpCodesEnum";
 import { LambdaInterface } from "@aws-lambda-powertools/commons";
 import { PostEventProcessor } from "./services/PostEventProcessor";
+import { Constants } from "./utils/Constants";
 
 const POWERTOOLS_METRICS_NAMESPACE = process.env.POWERTOOLS_METRICS_NAMESPACE;
 const POWERTOOLS_LOG_LEVEL = process.env.POWERTOOLS_LOG_LEVEL;
@@ -18,7 +21,7 @@ const metrics = new Metrics({ namespace: POWERTOOLS_METRICS_NAMESPACE, serviceNa
 class PostEventHandler implements LambdaInterface {
 
 	@metrics.logMetrics({ throwOnEmptyMetrics: false, captureColdStartMetric: true })
-	async handler(event: SQSEvent, context: any): Promise<SQSBatchResponse> {
+	async handler(event: SQSEvent, context: any): Promise<any> {
 
 		// clear PersistentLogAttributes set by any previous invocation, and add lambda context for this invocation
 		logger.setPersistentLogAttributes({});
@@ -45,7 +48,11 @@ class PostEventHandler implements LambdaInterface {
 
 			} catch (error: any) {
 				logger.error({ message: "SQS Event could not be processed", error });
-				return { batchItemFailures:[] };
+				if(body.event_name === Constants.IPV_F2F_USER_CANCEL_END && error.message === "Error updating session record") {
+					throw new AppError(HttpCodesEnum.BAD_REQUEST, "SQS Event could not be processed");
+				} else {
+					return { batchItemFailures:[] };
+				}
 			}
 
 		} else {

--- a/src/PostEventHandler.ts
+++ b/src/PostEventHandler.ts
@@ -49,7 +49,7 @@ class PostEventHandler implements LambdaInterface {
 			} catch (error: any) {
 				logger.error({ message: "SQS Event could not be processed", error });
 				if (body.event_name === Constants.IPV_F2F_USER_CANCEL_END && error.message === "Error updating session record") {
-					throw new AppError(HttpCodesEnum.BAD_REQUEST, "SQS Event could not be processed");
+					throw new AppError(HttpCodesEnum.SERVER_ERROR, "SQS Event could not be processed");
 				} else {
 					return { batchItemFailures:[] };
 				}

--- a/src/PostEventHandler.ts
+++ b/src/PostEventHandler.ts
@@ -1,4 +1,4 @@
-import { SQSEvent, SQSRecord } from "aws-lambda";
+import { SQSBatchResponse, SQSEvent, SQSRecord } from "aws-lambda";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { AppError } from "./utils/AppError";

--- a/src/PostEventHandler.ts
+++ b/src/PostEventHandler.ts
@@ -1,4 +1,4 @@
-import { SQSBatchResponse, SQSEvent, SQSRecord } from "aws-lambda";
+import { SQSEvent, SQSRecord } from "aws-lambda";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { Metrics } from "@aws-lambda-powertools/metrics";
 import { AppError } from "./utils/AppError";

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -217,10 +217,15 @@ export class PostEventProcessor {
 			}
 
 		} catch (error: any) {
+			if(error.message === "Error updating session record") {
+				this.logger.error({ message: "Failed to update session record in dynamo", error });
+				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error updating session record");
+			} else {
 			this.logger.error({ message: "Cannot parse event data", error });
 			throw new AppError(HttpCodesEnum.BAD_REQUEST, "Cannot parse event data");
 		}
 	}
+}
 
 	/**
 	 * Checks if all string values in the array are defined and does not

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -217,15 +217,15 @@ export class PostEventProcessor {
 			}
 
 		} catch (error: any) {
-			if(error.message === "Error updating session record") {
+			if (error.message === "Error updating session record") {
 				this.logger.error({ message: "Failed to update session record in dynamo", error });
 				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error updating session record");
 			} else {
-			this.logger.error({ message: "Cannot parse event data", error });
-			throw new AppError(HttpCodesEnum.BAD_REQUEST, "Cannot parse event data");
+				this.logger.error({ message: "Cannot parse event data", error });
+				throw new AppError(HttpCodesEnum.BAD_REQUEST, "Cannot parse event data");
+			}
 		}
 	}
-}
 
 	/**
 	 * Checks if all string values in the array are defined and does not

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -222,7 +222,7 @@ export class PostEventProcessor {
 				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error updating session record");
 			} else {
 				this.logger.error({ message: "Cannot parse event data", error });
-				throw new AppError(HttpCodesEnum.BAD_REQUEST, "Cannot parse event data");
+				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Cannot parse event data");
 			}
 		}
 	}

--- a/src/tests/data/sqs-events.ts
+++ b/src/tests/data/sqs-events.ts
@@ -200,6 +200,28 @@ export const VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT: ReturnSQSEvent = {
 
 export const VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT_STRING = JSON.stringify(VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT);
 
+export const VALID_IPV_F2F_USER_CANCEL_END_SQS_EVENT = {
+	"Records": [
+		{
+			"messageId": "6e67a34a-94f1-493f-b9eb-3d421aa701a8",
+			// pragma: allowlist nextline secret
+			"receiptHandle": "AQEBDzpW+TMqnd6I8zcqmrq8g8BTsuDjI745ci0bJ46g0Ej",
+			"body": VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT_STRING,
+			"attributes": {
+				"ApproximateReceiveCount": "1",
+				"SentTimestamp": "1588867971441",
+				"SenderId": "AIDAIVEA3AGEU7NF6DRAG",
+				"ApproximateFirstReceiveTimestamp": "1588867971443",
+			},
+			"messageAttributes": {},
+			// pragma: allowlist nextline secret
+			"md5OfBody": "ef38e4dfa52ade850f671b7e1915f26b",
+			"eventSource": "aws:sqs",
+			"eventSourceARN": "queue_arn",
+			"awsRegion": "eu-west-2",
+		},
+	],
+};
 
 export const VALID_GOV_NOTIFY_SQS_TXMA_EVENT = {
 	Message: {
@@ -211,7 +233,7 @@ export const VALID_GOV_NOTIFY_SQS_TXMA_EVENT = {
 	},
 };
 
-export const VALID_GOV_NOTIFY_SQS_TXMA_EVENTT_STRING = JSON.stringify(VALID_GOV_NOTIFY_SQS_TXMA_EVENT);
+export const VALID_GOV_NOTIFY_SQS_TXMA_EVENT_STRING = JSON.stringify(VALID_GOV_NOTIFY_SQS_TXMA_EVENT);
 
 export const VALID_F2F_DOCUMENT_UPLOADED_TXMA_EVENT: ReturnSQSEvent = {
 	"event_id": "588f4a66-f75a-4728-9f7b-8afd865c233e",

--- a/src/tests/unit/PostEventHandler.test.ts
+++ b/src/tests/unit/PostEventHandler.test.ts
@@ -37,7 +37,7 @@ describe("PostEventHandler", () => {
 		PostEventProcessor.getInstance = jest.fn().mockImplementation(() => {
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error updating session record");
 		});
-		await expect(lambdaHandler(VALID_IPV_F2F_USER_CANCEL_END_SQS_EVENT, "IPR")).rejects.toThrow(new AppError(HttpCodesEnum.BAD_REQUEST, "SQS Event could not be processed"));
+		await expect(lambdaHandler(VALID_IPV_F2F_USER_CANCEL_END_SQS_EVENT, "IPR")).rejects.toThrow(new AppError(HttpCodesEnum.SERVER_ERROR, "SQS Event could not be processed"));
 	});
 
 	it("errors with batchItemFailures when postEvent processor throws AppError for all other events", async () => {

--- a/src/tests/unit/PostEventHandler.test.ts
+++ b/src/tests/unit/PostEventHandler.test.ts
@@ -1,7 +1,7 @@
 import { mock } from "jest-mock-extended";
 import { lambdaHandler } from "../../PostEventHandler";
 import { PostEventProcessor } from "../../services/PostEventProcessor";
-import { VALID_AUTH_IPV_AUTHORISATION_REQUESTED_SQS_EVENT } from "../data/sqs-events";
+import { VALID_AUTH_IPV_AUTHORISATION_REQUESTED_SQS_EVENT, VALID_IPV_F2F_USER_CANCEL_END_SQS_EVENT } from "../data/sqs-events";
 import { AppError } from "../../utils/AppError";
 import { HttpCodesEnum } from "../../models/enums/HttpCodesEnum";
 
@@ -33,7 +33,14 @@ describe("PostEventHandler", () => {
 		expect(response.batchItemFailures).toEqual([]);
 	});
 
-	it("errors when postEvent processor throws AppError", async () => {
+	it("throws AppError when postEvent processor throws AppError for IPV_F2F_USER_CANCEL_END event", async () => {
+		PostEventProcessor.getInstance = jest.fn().mockImplementation(() => {
+			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error updating session record");
+		});
+		await expect(lambdaHandler(VALID_IPV_F2F_USER_CANCEL_END_SQS_EVENT, "IPR")).rejects.toThrow(new AppError(HttpCodesEnum.BAD_REQUEST, "SQS Event could not be processed"));
+	});
+
+	it("errors with batchItemFailures when postEvent processor throws AppError for all other events", async () => {
 		PostEventProcessor.getInstance = jest.fn().mockImplementation(() => {
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, "Missing event config");
 		});

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -459,8 +459,8 @@ describe("PostEventProcessor", () => {
 		it("throws AppError when IPRServiceSession throws AppError for IPV_F2F_USER_CANCEL_END event", async () => {
 			mockIprServiceSession.saveEventData.mockImplementation(() => {
 				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error updating session record");
-			})
+			});
 			await expect(postEventProcessorMockServices.processRequest(VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT_STRING)).rejects.toThrow(new AppError(HttpCodesEnum.SERVER_ERROR, "Error updating session record"));
-		})
-	})
+		});
+	});
 });

--- a/src/tests/unit/services/PostEventProcessor.test.ts
+++ b/src/tests/unit/services/PostEventProcessor.test.ts
@@ -49,7 +49,7 @@ describe("PostEventProcessor", () => {
 		postEventProcessorMockSessionService.iprServiceSession = mockIprServiceSession;
 		// @ts-ignore
 		postEventProcessorMockSessionService.iprServiceAuth = iprServiceAuth;
-		mockIprServiceSession.saveEventData.mockResolvedValueOnce();
+		mockIprServiceSession.saveEventData.mockResolvedValue();
 		mockIprServiceAuth.saveEventData.mockResolvedValueOnce();
 		mockIprServiceSession.obfuscateJSONValues.mockResolvedValue({ "event_name":"IPR_RESULT_NOTIFICATION_EMAILED", "user":{ "user_id":"***" }, "timestamp":"***" });
 	});
@@ -454,4 +454,13 @@ describe("PostEventProcessor", () => {
 			expect(mockLogger.error).toHaveBeenNthCalledWith(1, { "message": "F2F_YOTI_START event received before AUTH_IPV_AUTHORISATION_REQUESTED event" }, { "messageCode": "SQS_OUT_OF_SYNC" });	
 		});
 	});
+
+	describe("IPV_F2F_USER_CANCEL_END", () => {
+		it("throws AppError when IPRServiceSession throws AppError for IPV_F2F_USER_CANCEL_END event", async () => {
+			mockIprServiceSession.saveEventData.mockImplementation(() => {
+				throw new AppError(HttpCodesEnum.SERVER_ERROR, "Error updating session record");
+			})
+			await expect(postEventProcessorMockServices.processRequest(VALID_IPV_F2F_USER_CANCEL_END_TXMA_EVENT_STRING)).rejects.toThrow(new AppError(HttpCodesEnum.SERVER_ERROR, "Error updating session record"));
+		})
+	})
 });


### PR DESCRIPTION
### What changed

Error handling for IPV_F2F_USER_CANCEL_END event added - when Dynamo command to delete record fails, request retries 5 times then is put into DLQ. When the consumption of the event fails, a 500 is thrown and the message does not go to the DLQ

### Why did it change

To correctly handle errors involving the new TxMA event 

### Issue tracking

- [KIWI-2055](https://govukverify.atlassian.net/browse/KIWI-2055)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

![Screenshot 2024-12-17 at 11 48 31 (2)](https://github.com/user-attachments/assets/aaed425f-2e6b-4031-9541-a97a156a8f19)

![Screenshot 2024-12-17 at 11 48 35 (2)](https://github.com/user-attachments/assets/81edb8b5-56f8-4f71-b72f-13572679987f)

![Screenshot 2024-12-17 at 11 56 44](https://github.com/user-attachments/assets/143fc453-484e-41a0-9bb7-93b59a0e117f)








[KIWI-2055]: https://govukverify.atlassian.net/browse/KIWI-2055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ