### PR TITLE
[KIWI-2120] - Write unit tests for all methods of the JwtUtils class

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -108,5 +112,5 @@
     }
   ],
   "results": {},
-  "generated_at": "2023-04-12T10:47:07Z"
+  "generated_at": "2025-03-17T08:35:38Z"
 }

--- a/src/tests/api/utils/JwtUtils.test.ts
+++ b/src/tests/api/utils/JwtUtils.test.ts
@@ -1,0 +1,44 @@
+import { jwtUtils } from "../../../utils/JwtUtils";
+
+describe("jwtUtils", () => {
+	it("should base64 encode a string", () => {
+		const input = "This is a test string";
+		const expectedOutput = "VGhpcyBpcyBhIHRlc3Qgc3RyaW5n";
+		expect(jwtUtils.base64Encode(input)).toBe(expectedOutput);
+	});
+
+	it("should base64 decode a string to Uint8Array", () => {
+		const input = "VGhpcyBpcyBhIHRlc3Qgc3RyaW5n";
+		const expectedOutput = new Uint8Array([
+			84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 32,
+			115, 116, 114, 105, 110, 103,
+		]);
+		expect(jwtUtils.base64DecodeToUint8Array(input)).toEqual(
+			expectedOutput,
+		);
+	});
+
+	it("should base64 decode a string to string", () => {
+		const input = "VGhpcyBpcyBhIHRlc3Qgc3RyaW5n";
+		const expectedOutput = "This is a test string";
+		expect(jwtUtils.base64DecodeToString(input)).toBe(expectedOutput);
+	});
+
+	it("should decode a Uint8Array to string", () => {
+		const input = new Uint8Array([
+			84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 32,
+			115, 116, 114, 105, 110, 103,
+		]);
+		const expectedOutput = "This is a test string";
+		expect(jwtUtils.decode(input)).toBe(expectedOutput);
+	});
+
+	it("should encode a string to Uint8Array", () => {
+		const input = "This is a test string";
+		const expectedOutput = new Uint8Array([
+			84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 116, 101, 115, 116, 32,
+			115, 116, 114, 105, 110, 103,
+		]);
+		expect(jwtUtils.encode(input)).toEqual(expectedOutput);
+	});
+});


### PR DESCRIPTION
### What changed

Adds unit tests for JwtUtils module

### Why did it change

To increase code coverage and dependability of service

### Issue tracking

- [KIWI-2120](https://govukverify.atlassian.net/browse/KIWI-2120)

### Evidence

![image](https://github.com/user-attachments/assets/0d78cf36-760a-4277-a19e-cb6754d071e6)

[KIWI-2120]: https://govukverify.atlassian.net/browse/KIWI-2120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ