### PR TITLE
KIWI-1576] -IPR | BE | TxMA Config Changes to Enable PO Failure Email

### DIFF
--- a/src/models/ReturnSQSEvent.ts
+++ b/src/models/ReturnSQSEvent.ts
@@ -1,6 +1,6 @@
 import { NamePart, PostOfficeVisitDetails, PostOfficeInfo, DocumentDetails } from "./SessionReturnRecord";
 
-export type EventType = "AUTH_IPV_AUTHORISATION_REQUESTED" | "F2F_YOTI_START" | "IPV_F2F_CRI_VC_CONSUMED" | "AUTH_DELETE_ACCOUNT" | "F2F_DOCUMENT_UPLOADED" | "IPV_F2F_USER_CANCEL_END";
+export type EventType = "AUTH_IPV_AUTHORISATION_REQUESTED" | "F2F_YOTI_START" | "IPV_F2F_CRI_VC_CONSUMED" | "AUTH_DELETE_ACCOUNT" | "F2F_DOCUMENT_UPLOADED" | "IPV_F2F_USER_CANCEL_END" | "IPV_F2F_CRI_VC_ERROR";
 
 
 export interface ReturnSQSEvent {
@@ -26,6 +26,7 @@ export interface ReturnSQSEvent {
 	extensions?: {
 		post_office_visit_details?: PostOfficeVisitDetails[];
 		post_office_details?: PostOfficeInfo[];
+    	error_description?: string;
 	};
 }
 

--- a/src/models/SessionReturnRecord.ts
+++ b/src/models/SessionReturnRecord.ts
@@ -36,7 +36,6 @@ export interface DocumentTypeDetails {
 
 export class SessionReturnRecord {
 	constructor(data: ReturnSQSEvent, expiresOn: number) {
-		this.userId = data.user.user_id;
 		switch (data.event_name) {
 			case Constants.AUTH_IPV_AUTHORISATION_REQUESTED:{
 				this.clientName = data.client_id!;
@@ -49,6 +48,7 @@ export class SessionReturnRecord {
 			case Constants.F2F_YOTI_START: {
 				this.journeyWentAsyncOn = data.timestamp;
 				this.expiresDate = expiresOn;
+				this.nameParts = data.restricted?.nameParts;
 				if (data.user.govuk_signin_journey_id && (data.user.govuk_signin_journey_id).toLowerCase() !== "unknown") {
 					this.clientSessionId = data.user.govuk_signin_journey_id;
 				}
@@ -85,13 +85,18 @@ export class SessionReturnRecord {
 				this.nameParts = [];
 				break;
 			}
+			case Constants.IPV_F2F_CRI_VC_ERROR: {
+				this.userId = data.user.user_id;
+				this.error_description = data.extensions?.error_description;
+				break;
+			}
 			default: {
 				break;
 			}
 		}
 	}
 
-    userId: string;
+    userId?: string;
 
     userEmail?: string;
 
@@ -122,4 +127,6 @@ export class SessionReturnRecord {
 	documentType?: string;
 
 	documentExpiryDate?: string;
+
+	error_description?: string;
 }

--- a/src/services/PostEventProcessor.ts
+++ b/src/services/PostEventProcessor.ts
@@ -150,6 +150,7 @@ export class PostEventProcessor {
 						":redirectUri": fetchedRecord.redirectUri,
 						":journeyWentAsyncOn": returnRecord.journeyWentAsyncOn,
 						":expiresOn": returnRecord.expiresDate,
+						":nameParts": returnRecord.nameParts,
 					};
 					if (returnRecord.postOfficeInfo) {
 						updateExpression += ", postOfficeInfo = :postOfficeInfo";
@@ -210,9 +211,17 @@ export class PostEventProcessor {
 					expressionAttributeValues = {
 						":accountDeletedOn": returnRecord.accountDeletedOn,
 						":userEmail": returnRecord.userEmail,
-						":nameParts":returnRecord.nameParts,
+						":nameParts": returnRecord.nameParts,
 						":clientName": returnRecord.clientName,
 						":redirectUri": returnRecord.redirectUri,
+					};
+					break;
+				}
+				case Constants.IPV_F2F_CRI_VC_ERROR: {
+					updateExpression = "SET userId = :userId, errorDescription = :errorDescription";
+					expressionAttributeValues = {
+						":userId": returnRecord.userId,
+						":errorDescription": returnRecord.error_description,
 					};
 					break;
 				}

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -23,6 +23,8 @@ export class Constants {
     static readonly AUTH_DELETE_ACCOUNT = "AUTH_DELETE_ACCOUNT";
 
     static readonly IPV_F2F_USER_CANCEL_END = "IPV_F2F_USER_CANCEL_END";
+    
+    static readonly IPV_F2F_CRI_VC_ERROR = "IPV_F2F_CRI_VC_ERROR";
 
     static readonly POSTEVENT_LOGGER_SVC_NAME = "PostEventHandler";
 


### PR DESCRIPTION
### What changed

Changes made to allow IPR to consume the IPV_F2F_CRI_VC_ERROR TxMA event

### Why did it change

To enable sending of failure emails to users

### Issue tracking
- [KIWI-1576](https://govukverify.atlassian.net/browse/KIWI-1576)
