### PR TITLE
[KIWI-2479] - IPR | Add FMS tags for custom WAF policy migration in lower environments

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -233,6 +233,10 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
+  IsDevOrBuildOrStaging: !Or
+    - !Equals [ !Ref Environment, dev ]
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -685,8 +689,8 @@ Resources:
         Service: backend
         Name: CICRestApi
         Source: alphagov/di-devplatform-demo-sam-app/sam-app/template.yaml
-        FMSRegionalPolicy: false
-        CustomPolicy: true
+        FMSRegionalPolicy: !If [ IsDevOrBuildOrStaging, "false", "none" ]
+        CustomPolicy: !If [ IsDevOrBuildOrStaging, "true", "none" ]
 
   IPVRAPIGatewayAccessLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
### What changed

Added Firewall Manager (FMS) tags to template file

### Why did it change

To accommodate a transition from COUNT (logging rule violations) to BLOCK (actively blocking rule violations) in the lower environments

### Issue tracking
- [KIWI-2479](https://govukverify.atlassian.net/browse/KIWI-2479)

#### Tags in Stages

<img width="716" height="482" alt="Screenshot 2025-10-03 at 12 23 20" src="https://github.com/user-attachments/assets/c6cd6bf1-e1e7-445f-b7f7-5eb4b91d94ac" />


[KIWI-2476]: https://govukverify.atlassian.net/browse/KIWI-2476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KIWI-2479]: https://govukverify.atlassian.net/browse/KIWI-2479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ